### PR TITLE
Docs: Add `avatar-test` class and background style to ChatAvatar examples

### DIFF
--- a/src/MudX.Docs/Components/Docs/Chat/Examples/ChatAvatarExample.razor
+++ b/src/MudX.Docs/Components/Docs/Chat/Examples/ChatAvatarExample.razor
@@ -1,7 +1,7 @@
 @namespace MudX.Docs.Chat
 @using MudX
 
-<MudXChat ChatPosition="MudX.ChatBubblePosition.Start">
+<MudXChat Class="avatar-test" ChatPosition="MudX.ChatBubblePosition.Start">
     <MudAvatar>OK</MudAvatar>
     <MudXChatBubble>
         It was said that you would, destroy the Sith, not join them.
@@ -11,7 +11,7 @@
     </MudXChatBubble>
 </MudXChat>
 
-<MudXChat ChatPosition="MudX.ChatBubblePosition.Start">
+<MudXChat Class="avatar-test" ChatPosition="MudX.ChatBubblePosition.Start">
     <MudAvatar>
         <MudImage Src="./_content/MudX.Docs/images/jonny.jpg" />
     </MudAvatar>
@@ -19,3 +19,10 @@
         Not leave it in Darkness
     </MudXChatBubble>
 </MudXChat>
+
+
+<style>
+    .avatar-test .mudx-chat-text {
+        background-color: #d4d7dc;
+    }
+</style>

--- a/src/MudX.Docs/Components/Examples/ChatAvatarExample.g.cs
+++ b/src/MudX.Docs/Components/Examples/ChatAvatarExample.g.cs
@@ -13,7 +13,7 @@ namespace MudX.Docs.Examples
                 Code: @"@namespace MudX.Docs.Chat
 @using MudX
 
-<MudXChat ChatPosition=""MudX.ChatBubblePosition.Start"">
+<MudXChat Class=""avatar-test"" ChatPosition=""MudX.ChatBubblePosition.Start"">
     <MudAvatar>OK</MudAvatar>
     <MudXChatBubble>
         It was said that you would, destroy the Sith, not join them.
@@ -23,7 +23,7 @@ namespace MudX.Docs.Examples
     </MudXChatBubble>
 </MudXChat>
 
-<MudXChat ChatPosition=""MudX.ChatBubblePosition.Start"">
+<MudXChat Class=""avatar-test"" ChatPosition=""MudX.ChatBubblePosition.Start"">
     <MudAvatar>
         <MudImage Src=""./_content/MudX.Docs/images/jonny.jpg"" />
     </MudAvatar>
@@ -31,6 +31,12 @@ namespace MudX.Docs.Examples
         Not leave it in Darkness
     </MudXChatBubble>
 </MudXChat>
+
+<style>
+    .avatar-test .mudx-chat-text {
+        background-color: #d4d7dc;
+    }
+</style>
 ",
                 Language: CodeLanguage.Razor
             )

--- a/tests/MudX.UnitTests/Components/ChatTests.cs
+++ b/tests/MudX.UnitTests/Components/ChatTests.cs
@@ -184,5 +184,6 @@ namespace MudX.UnitTests.Components
 
             comp.Markup.Should().Contain("Custom Footer Content");
         }
+
     }
 }

--- a/tests/MudX.UnitTests/Components/ChatTests.cs
+++ b/tests/MudX.UnitTests/Components/ChatTests.cs
@@ -184,6 +184,5 @@ namespace MudX.UnitTests.Components
 
             comp.Markup.Should().Contain("Custom Footer Content");
         }
-
     }
 }


### PR DESCRIPTION
### Motivation
- Make the Chat avatar examples visually distinct by applying a custom class and a background color to the chat text for demonstration purposes.

### Description
- Added `Class="avatar-test"` to the `MudXChat` instances in `ChatAvatarExample.razor` and updated the generated example file `ChatAvatarExample.g.cs` to match.
- Added an inline `<style>` block that targets `.avatar-test .mudx-chat-text` and sets a background color of `#d4d7dc` to highlight the avatar example.
- Minor whitespace/formatting adjustment in `tests/MudX.UnitTests/Components/ChatTests.cs` with no behavioral change to tests.

### Testing
- Ran the unit test suite in `tests/MudX.UnitTests`, including `ChatTests`, and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7c881cd8832d8a41f6754aec7f20)