### PR TITLE
MudXChat: Enhance docs and examples with CSS styling

### DIFF
--- a/src/MudX.Docs/Components/Docs/Chat/ChatDocPage.razor
+++ b/src/MudX.Docs/Components/Docs/Chat/ChatDocPage.razor
@@ -27,7 +27,8 @@
 
         <DocsPageSection Title="With Avatar">
                 <Description>
-                    MudXChat can include an avatar, which works seamlessly with the <CodeInline>MudAvatar</CodeInline> component. The avatar will always appear on the first <CodeInline>MudXChatBubble</CodeInline> inside a MudXChat.
+                    MudXChat can include an avatar, which works seamlessly with the <CodeInline>MudAvatar</CodeInline> component. The avatar will always appear on the first <CodeInline>MudXChatBubble</CodeInline> inside a MudXChat. 
+                    You can also see how easy it is to target a css style for a single bubble, all bubbles in a chat, etc. 
                 </Description>
             <ChildContent>
                 <SectionContent Codes="ChatAvatarExampleCode.Files">

--- a/src/MudX.Docs/Components/Docs/Chat/Examples/ChatAvatarExample.razor
+++ b/src/MudX.Docs/Components/Docs/Chat/Examples/ChatAvatarExample.razor
@@ -1,7 +1,7 @@
 @namespace MudX.Docs.Chat
 @using MudX
 
-<MudXChat ChatPosition="MudX.ChatBubblePosition.Start">
+<MudXChat Class="avatar-docs-show" ChatPosition="MudX.ChatBubblePosition.Start">
     <MudAvatar>OK</MudAvatar>
     <MudXChatBubble>
         It was said that you would, destroy the Sith, not join them.
@@ -19,3 +19,9 @@
         Not leave it in Darkness
     </MudXChatBubble>
 </MudXChat>
+
+<style>
+    .avatar-docs-show .mudx-chat-text {
+        background-color: #d4d7dc;
+    }
+</style>


### PR DESCRIPTION
### Motivation
- Make the Chat avatar examples visually distinct by applying a custom class and a background color to the chat text for demonstration purposes.

### Description
- Added `Class="avatar-docs-show` to the `MudXChat` instance in `ChatAvatarExample.razor` and updated the ChatDocPage to match.
- Added an inline `<style>` block that targets `.avatar-docs-show .mudx-chat-text` and sets a background color of `#d4d7dc` for the Text Variant to highlight the avatar example. (match the color of the avatar background.

### Testing
- Ran the unit test suite in `tests/MudX.UnitTests`, including `ChatTests`, and all tests passed successfully

Closes #56 
Closes #57 