### PR TITLE
Docs: Preserve XML doc references in generated API text

### DIFF
--- a/src/MudX.Docs.Generator/ApiSource.cs
+++ b/src/MudX.Docs.Generator/ApiSource.cs
@@ -262,11 +262,58 @@ namespace MudX.Docs.Generator
                     x => x.Attribute("name")!.Value,
                     x =>
                     {
-                        var summary = x.Element("summary")?.Value ?? "";
-                        var remarks = x.Element("remarks")?.Value ?? "";
+                        var summary = GetXmlDocElementText(x.Element("summary"));
+                        var remarks = GetXmlDocElementText(x.Element("remarks"));
                         return CleanXmlDoc(summary, remarks);
                     }
                 );
+        }
+
+        private static string GetXmlDocElementText(XElement? element)
+        {
+            if (element is null)
+                return string.Empty;
+
+            return string.Concat(element.Nodes().Select(GetXmlDocNodeText));
+        }
+
+        private static string GetXmlDocNodeText(XNode node)
+        {
+            if (node is XText text)
+                return text.Value;
+
+            if (node is not XElement element)
+                return string.Empty;
+
+            return element.Name.LocalName switch
+            {
+                "see" or "seealso" => GetXmlDocReferenceText(element),
+                "paramref" or "typeparamref" => element.Attribute("name")?.Value ?? string.Empty,
+                "c" or "code" => element.Value,
+                "para" => $" {GetXmlDocElementText(element)} ",
+                "br" => " ",
+                _ => GetXmlDocElementText(element)
+            };
+        }
+
+        private static string GetXmlDocReferenceText(XElement element)
+        {
+            var langword = element.Attribute("langword")?.Value;
+            if (!string.IsNullOrWhiteSpace(langword))
+                return langword;
+
+            var cref = element.Attribute("cref")?.Value;
+            if (string.IsNullOrWhiteSpace(cref))
+                return GetXmlDocElementText(element);
+
+            var memberName = cref.Contains(':') ? cref[(cref.IndexOf(':') + 1)..] : cref;
+            var parametersStart = memberName.IndexOf('(');
+            if (parametersStart >= 0)
+                memberName = memberName[..parametersStart];
+
+            var displayName = memberName[(memberName.LastIndexOf('.') + 1)..];
+            var genericMarker = displayName.IndexOf('`');
+            return genericMarker >= 0 ? displayName[..genericMarker] : displayName;
         }
 
         private static string GetFriendlyTypeName(Type type)

--- a/src/MudX.Docs.Generator/ApiSource.cs
+++ b/src/MudX.Docs.Generator/ApiSource.cs
@@ -306,6 +306,10 @@ namespace MudX.Docs.Generator
             if (string.IsNullOrWhiteSpace(cref))
                 return GetXmlDocElementText(element);
 
+            var innerText = GetXmlDocElementText(element);
+            if (!string.IsNullOrWhiteSpace(innerText))
+                return innerText;
+
             var memberName = cref.Contains(':') ? cref[(cref.IndexOf(':') + 1)..] : cref;
             var parametersStart = memberName.IndexOf('(');
             if (parametersStart >= 0)

--- a/src/MudX.Docs/wwwroot/api/LottieAnimationOptions.api.json
+++ b/src/MudX.Docs/wwwroot/api/LottieAnimationOptions.api.json
@@ -13,12 +13,12 @@
     {
       "Name": "AnimationQuality",
       "Type": "LottieAnimationQuality",
-      "Description": "Gets or sets the quality level of the Lottie animation rendering. This is a global setting.\nRemarks: Defaults to . Higher quality levels may result in smoother animations but could increase resource usage."
+      "Description": "Gets or sets the quality level of the Lottie animation rendering. This is a global setting.\nRemarks: Defaults to High. Higher quality levels may result in smoother animations but could increase resource usage."
     },
     {
       "Name": "SmoothFrameInterpolation",
       "Type": "Boolean",
-      "Description": "Gets or sets whether to enable smooth frame interpolation for high refresh rate displays.\nRemarks: When true (default), the animation will interpolate between keyframes to create smooth motion that adapts to your display\u0027s refresh rate (60Hz, 120Hz, etc.).When false, the animation will only update on the original After Effects keyframes, which may appear choppy on high refresh displays but offers better performance and pixel-perfect reproduction of the original animation timing."
+      "Description": "Gets or sets whether to enable smooth frame interpolation for high refresh rate displays.\nRemarks: When true (default), the animation will interpolate between keyframes to create smooth motion that adapts to your display\u0027s refresh rate (60Hz, 120Hz, etc.). When false, the animation will only update on the original After Effects keyframes, which may appear choppy on high refresh displays but offers better performance and pixel-perfect reproduction of the original animation timing."
     }
   ],
   "PublicFields": [],
@@ -32,13 +32,13 @@
           "Type": "Object"
         }
       ],
-      "Description": "Determines whether the specified object is equal to the current instance.\nRemarks: Two instances are considered equal if they have the same , , and values."
+      "Description": "Determines whether the specified object is equal to the current instance.\nRemarks: Two instances are considered equal if they have the same LottieSourceJs, AnimationQuality, and SmoothFrameInterpolation values."
     },
     {
       "Name": "GetHashCode",
       "ReturnType": "Int32",
       "Parameters": [],
-      "Description": "Returns a hash code for the current object.\nRemarks: The hash code is computed based on the values of the , , and properties. This ensures that objects with the same property values produce the same hash code."
+      "Description": "Returns a hash code for the current object.\nRemarks: The hash code is computed based on the values of the LottieSourceJs, AnimationQuality, and SmoothFrameInterpolation properties. This ensures that objects with the same property values produce the same hash code."
     }
   ]
 }

--- a/src/MudX.Docs/wwwroot/api/LottiePlayer.api.json
+++ b/src/MudX.Docs/wwwroot/api/LottiePlayer.api.json
@@ -1,7 +1,7 @@
 {
   "Component": "LottiePlayer",
   "Namespace": "Blazor.Lottie.Player",
-  "Description": "A Blazor component for rendering and controlling Lottie animations using BodyMovin.\nRemarks: The component provides a flexible way to integrate Lottie animations into Blazor applications. It supports various customization options, including animation source, playback settings, and event callbacks for animation lifecycle events.",
+  "Description": "A Blazor component for rendering and controlling Lottie animations using BodyMovin.\nRemarks: The LottiePlayer component provides a flexible way to integrate Lottie animations into Blazor applications. It supports various customization options, including animation source, playback settings, and event callbacks for animation lifecycle events.",
   "Parameters": [
     {
       "Name": "Class",
@@ -43,37 +43,37 @@
       "Name": "LoopCount",
       "Type": "Int32",
       "Default": "0",
-      "Description": "Gets or sets the number of times a loop should occur. Requires to be true.\nRemarks: Default is 0 (infinite loop)."
+      "Description": "Gets or sets the number of times a loop should occur. Requires Loop to be true.\nRemarks: Default is 0 (infinite loop)."
     },
     {
       "Name": "AnimationType",
       "Type": "LottieAnimationType",
       "Default": "Svg",
-      "Description": "Gets or sets the type of animation to be used for rendering the Lottie animation.\nRemarks: Defaults to ."
+      "Description": "Gets or sets the type of animation to be used for rendering the Lottie animation.\nRemarks: Defaults to Svg."
     },
     {
       "Name": "AnimationDirection",
       "Type": "LottieAnimationDirection",
       "Default": "Forward",
-      "Description": "Gets or sets the direction in which the Lottie animation plays.\nRemarks: Defaults to . Changing this property after initialization will not change the playback direction of the animation, use"
+      "Description": "Gets or sets the direction in which the Lottie animation plays.\nRemarks: Defaults to Forward. Changing this property after initialization will not change the playback direction of the animation, use SetDirectionAsync"
     },
     {
       "Name": "AnimationSpeed",
       "Type": "Double",
       "Default": "1",
-      "Description": "Gets or sets the speed of the animation.\nRemarks: Defaults to 1.0 (normal speed). Changing this property after initialization will not change the speed of the animation, use"
+      "Description": "Gets or sets the speed of the animation.\nRemarks: Defaults to 1.0 (normal speed). Changing this property after initialization will not change the speed of the animation, use SetSpeedAsync"
     },
     {
       "Name": "CurrentFrameChangeFunc",
       "Type": "Func\u003CDouble, Boolean\u003E",
       "Default": "null",
-      "Description": "Called when the current frame changes, with custom filtering logic\nRemarks: The function receives the current frame number and should return true if the event should be raised. This allows for custom throttling logic (e.g., only every 10th frame, only on specific frames, etc.) Warning: Frame updates could happen as frequently as 30-60 times per second. Defaults to null. is only raised if something is attached to the handler. Example: frame =\u003E frame % 10 == 0 will raise the event every 10th frame."
+      "Description": "Called when the current frame changes, with custom filtering logic\nRemarks: The function receives the current frame number and should return true if the event should be raised. This allows for custom throttling logic (e.g., only every 10th frame, only on specific frames, etc.) Warning: Frame updates could happen as frequently as 30-60 times per second. Defaults to null. CurrentFrameChanged is only raised if something is attached to the handler. Example: frame =\u003E frame % 10 == 0 will raise the event every 10th frame."
     },
     {
       "Name": "CurrentFrameChanged",
       "Type": "EventCallback\u003CLottiePlayerEventFrameArgs\u003E",
       "Default": "",
-      "Description": "Called when the current frame changes (only when returns true)"
+      "Description": "Called when the current frame changes (only when CurrentFrameChangeFunc returns true)"
     },
     {
       "Name": "DOMLoaded",
@@ -103,7 +103,7 @@
       "Name": "AnimationOptions",
       "Type": "LottieAnimationOptions",
       "Default": null,
-      "Description": "Additional Less Used Animation Options.\nRemarks: Refer to for defaults."
+      "Description": "Additional Less Used Animation Options.\nRemarks: Refer to LottieAnimationOptions for defaults."
     }
   ],
   "Events": [],

--- a/src/MudX.Docs/wwwroot/api/LottiePlayerModule.api.json
+++ b/src/MudX.Docs/wwwroot/api/LottiePlayerModule.api.json
@@ -123,7 +123,7 @@
           "Type": "LottiePlayerLoadedEventArgs"
         }
       ],
-      "Description": "Invokes the event when the animation is ready. (DOMLoaded)"
+      "Description": "Invokes the OnAnimationReady event when the animation is ready. (DOMLoaded)"
     },
     {
       "Name": "DOMLoadedEvent",
@@ -134,19 +134,19 @@
           "Type": "LottiePlayerLoadedEventArgs"
         }
       ],
-      "Description": "Invokes the event when the DOM is fully loaded with the Lottie animation."
+      "Description": "Invokes the OnDOMLoaded event when the DOM is fully loaded with the Lottie animation."
     },
     {
       "Name": "CompleteEvent",
       "ReturnType": "Task",
       "Parameters": [],
-      "Description": "Invokes the event when the animation completes.\nRemarks: This event is triggered when the animation has finished playing all frames and loops, if applicable. If it\u0027s set to loop indefinitely, this event will never be triggered."
+      "Description": "Invokes the OnComplete event when the animation completes.\nRemarks: This event is triggered when the animation has finished playing all frames and loops, if applicable. If it\u0027s set to loop indefinitely, this event will never be triggered."
     },
     {
       "Name": "LoopCompleteEvent",
       "ReturnType": "Task",
       "Parameters": [],
-      "Description": "Invokes the event when a loop completes."
+      "Description": "Invokes the OnLoopComplete event when a loop completes."
     },
     {
       "Name": "EnterFrameEvent",
@@ -157,7 +157,7 @@
           "Type": "LottiePlayerEventFrameArgs"
         }
       ],
-      "Description": "Invokes the event with the specified arguments."
+      "Description": "Invokes the OnEnterFrame event with the specified arguments."
     }
   ]
 }

--- a/src/MudX.Docs/wwwroot/api/MudXBreadcrumbs.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXBreadcrumbs.api.json
@@ -19,7 +19,7 @@
       "Name": "Separator",
       "Type": "String",
       "Default": "/",
-      "Description": "The separator shown between items.\nRemarks: Defaults to /. Will not be shown if is set."
+      "Description": "The separator shown between items.\nRemarks: Defaults to /. Will not be shown if SeparatorTemplate is set."
     },
     {
       "Name": "SeparatorTemplate",
@@ -37,25 +37,25 @@
       "Name": "MaxItems",
       "Type": "Nullable\u003CByte\u003E",
       "Default": "null",
-      "Description": "The maximum number of items to display.\nRemarks: Defaults to null. If is true and the number of items exceeds this value, the breadcrumbs will automatically collapse."
+      "Description": "The maximum number of items to display.\nRemarks: Defaults to null. If Collapsed is true and the number of items exceeds this value, the breadcrumbs will automatically collapse."
     },
     {
       "Name": "ExpanderIcon",
       "Type": "String",
       "Default": "\u003Cpath d=\u0022M0 0h24v24H0z\u0022 fill=\u0022none\u0022/\u003E\u003Cpath d=\u0022M7.77 6.76L6.23 5.48.82 12l5.41 6.52 1.54-1.28L3.42 12l4.35-5.24zM7 13h2v-2H7v2zm10-2h-2v2h2v-2zm-6 2h2v-2h-2v2zm6.77-7.52l-1.54 1.28L20.58 12l-4.35 5.24 1.54 1.28L23.18 12l-5.41-6.52z\u0022/\u003E",
-      "Description": "The icon to display when items are collapsed.\nRemarks: Defaults to . Displays when and the number of items exceeds ."
+      "Description": "The icon to display when items are collapsed.\nRemarks: Defaults to SettingsEthernet. Displays when Collapsed and the number of items exceeds MaxItems."
     },
     {
       "Name": "Class",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the property to apply custom CSS styles."
+      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the Style property to apply custom CSS styles."
     },
     {
       "Name": "Style",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the property to apply CSS classes."
+      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the Class property to apply CSS classes."
     },
     {
       "Name": "Tag",

--- a/src/MudX.Docs/wwwroot/api/MudXBreadcrumbsBase.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXBreadcrumbsBase.api.json
@@ -19,7 +19,7 @@
       "Name": "Separator",
       "Type": "String",
       "Default": "/",
-      "Description": "The separator shown between items.\nRemarks: Defaults to /. Will not be shown if is set."
+      "Description": "The separator shown between items.\nRemarks: Defaults to /. Will not be shown if SeparatorTemplate is set."
     },
     {
       "Name": "SeparatorTemplate",
@@ -37,25 +37,25 @@
       "Name": "MaxItems",
       "Type": "Nullable\u003CByte\u003E",
       "Default": "null",
-      "Description": "The maximum number of items to display.\nRemarks: Defaults to null. If is true and the number of items exceeds this value, the breadcrumbs will automatically collapse."
+      "Description": "The maximum number of items to display.\nRemarks: Defaults to null. If Collapsed is true and the number of items exceeds this value, the breadcrumbs will automatically collapse."
     },
     {
       "Name": "ExpanderIcon",
       "Type": "String",
       "Default": "\u003Cpath d=\u0022M0 0h24v24H0z\u0022 fill=\u0022none\u0022/\u003E\u003Cpath d=\u0022M7.77 6.76L6.23 5.48.82 12l5.41 6.52 1.54-1.28L3.42 12l4.35-5.24zM7 13h2v-2H7v2zm10-2h-2v2h2v-2zm-6 2h2v-2h-2v2zm6.77-7.52l-1.54 1.28L20.58 12l-4.35 5.24 1.54 1.28L23.18 12l-5.41-6.52z\u0022/\u003E",
-      "Description": "The icon to display when items are collapsed.\nRemarks: Defaults to . Displays when and the number of items exceeds ."
+      "Description": "The icon to display when items are collapsed.\nRemarks: Defaults to SettingsEthernet. Displays when Collapsed and the number of items exceeds MaxItems."
     },
     {
       "Name": "Class",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the property to apply custom CSS styles."
+      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the Style property to apply custom CSS styles."
     },
     {
       "Name": "Style",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the property to apply CSS classes."
+      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the Class property to apply CSS classes."
     },
     {
       "Name": "Tag",

--- a/src/MudX.Docs/wwwroot/api/MudXCodeBlock.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXCodeBlock.api.json
@@ -37,13 +37,13 @@
       "Name": "CopyOrigin",
       "Type": "Nullable\u003COrigin\u003E",
       "Default": "TopRight",
-      "Description": "The Copy Button Origin, nullable field indicating where the copy button should be placed. If null no button will be rendered.\nRemarks: Defaults to"
+      "Description": "The Copy Button Origin, nullable field indicating where the copy button should be placed. If null no button will be rendered.\nRemarks: Defaults to TopRight"
     },
     {
       "Name": "CopyIcon",
       "Type": "String",
       "Default": "\u003Cpath d=\u0022M0 0h24v24H0z\u0022 fill=\u0022none\u0022/\u003E\u003Cpath d=\u0022M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z\u0022/\u003E",
-      "Description": "The Copy Button Icon\nRemarks: Defaults to"
+      "Description": "The Copy Button Icon\nRemarks: Defaults to ContentCopy"
     },
     {
       "Name": "CopyButtonClassname",
@@ -55,13 +55,13 @@
       "Name": "Class",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the property to apply custom CSS styles."
+      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the Style property to apply custom CSS styles."
     },
     {
       "Name": "Style",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the property to apply CSS classes."
+      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the Class property to apply CSS classes."
     },
     {
       "Name": "Tag",

--- a/src/MudX.Docs/wwwroot/api/MudXOutline.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXOutline.api.json
@@ -1,13 +1,13 @@
 {
   "Component": "MudXOutline",
   "Namespace": "MudX",
-  "Description": "Represents a Table of Contents (TOC) component that provides navigation links to sections within a document.\nRemarks: The component allows users to navigate through sections of a document or page. It supports features such as customizable styling, scroll spying, and dynamic section registration. The TOC can be positioned on the left or right side of the viewport and includes options for rendering additional content above or below the section links.",
+  "Description": "Represents a Table of Contents (TOC) component that provides navigation links to sections within a document.\nRemarks: The MudXOutline component allows users to navigate through sections of a document or page. It supports features such as customizable styling, scroll spying, and dynamic section registration. The TOC can be positioned on the left or right side of the viewport and includes options for rendering additional content above or below the section links.",
   "Parameters": [
     {
       "Name": "ContentDrawerOpen",
       "Type": "Boolean",
       "Default": "true",
-      "Description": "Whether the Table of Contents drawer is open or closed\nRemarks: Defaults to"
+      "Description": "Whether the Table of Contents drawer is open or closed\nRemarks: Defaults to true"
     },
     {
       "Name": "Width",
@@ -19,7 +19,7 @@
       "Name": "Color",
       "Type": "Color",
       "Default": "Transparent",
-      "Description": "The color of the Table of Contents drawer\nRemarks: Defaults to"
+      "Description": "The color of the Table of Contents drawer\nRemarks: Defaults to Transparent"
     },
     {
       "Name": "Headline",
@@ -37,13 +37,13 @@
       "Name": "UnderlineActiveSections",
       "Type": "Boolean",
       "Default": "true",
-      "Description": "Whether to underline the active section\nRemarks: Defaults to"
+      "Description": "Whether to underline the active section\nRemarks: Defaults to true"
     },
     {
       "Name": "ScrollToTopVisible",
       "Type": "Boolean",
       "Default": "true",
-      "Description": "Whether the scroll to top button is visible\nRemarks: Defaults to"
+      "Description": "Whether the scroll to top button is visible\nRemarks: Defaults to true"
     },
     {
       "Name": "ChildContent",
@@ -67,7 +67,7 @@
       "Name": "Anchor",
       "Type": "Anchor",
       "Default": "Right",
-      "Description": "Where you want the Table of Contents to be rendered\nRemarks: Defaults to . Only Valid values are and ."
+      "Description": "Where you want the Table of Contents to be rendered\nRemarks: Defaults to Right. Only Valid values are Left and Right."
     },
     {
       "Name": "ScrollContainerSelector",
@@ -79,31 +79,31 @@
       "Name": "SectionClassSelector",
       "Type": "String",
       "Default": "mudx-toc-section",
-      "Description": "The class name to identify the HTML elements that should be observed for viewport changes inside the .\nRemarks: Defaults to \u0022mudx-toc-section\u0022"
+      "Description": "The class name to identify the HTML elements that should be observed for viewport changes inside the ScrollContainerSelector.\nRemarks: Defaults to \u0022mudx-toc-section\u0022"
     },
     {
       "Name": "StyleVariant",
       "Type": "OutlineStyleVariant",
       "Default": "Scroll",
-      "Description": "The Style Variant to apply to the Table of Contents area. Options are Bullet, Scroll, Minimal, and None.\nRemarks: Defaults to"
+      "Description": "The Style Variant to apply to the Table of Contents area. Options are Bullet, Scroll, Minimal, and None.\nRemarks: Defaults to Scroll"
     },
     {
       "Name": "TOCBreakpoint",
       "Type": "Breakpoint",
       "Default": "Md",
-      "Description": "The Breakpoint at which to hide the Table of Contents\nRemarks: Defaults to"
+      "Description": "The Breakpoint at which to hide the Table of Contents\nRemarks: Defaults to Md"
     },
     {
       "Name": "Class",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the property to apply custom CSS styles."
+      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the Style property to apply custom CSS styles."
     },
     {
       "Name": "Style",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the property to apply CSS classes."
+      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the Class property to apply CSS classes."
     },
     {
       "Name": "Tag",

--- a/src/MudX.Docs/wwwroot/api/MudXOutlineSection.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXOutlineSection.api.json
@@ -1,7 +1,7 @@
 {
   "Component": "MudXOutlineSection",
   "Namespace": "MudX",
-  "Description": "Represents a section within an outline or table of contents, providing hierarchical structure and navigation capabilities.\nRemarks: This class is used to define sections in a document outline, supporting features such as hierarchical levels, scrolling behavior, and active state tracking. Sections can be nested within parent containers, and their properties such as and are used for display and navigation.",
+  "Description": "Represents a section within an outline or table of contents, providing hierarchical structure and navigation capabilities.\nRemarks: This class is used to define sections in a document outline, supporting features such as hierarchical levels, scrolling behavior, and active state tracking. Sections can be nested within parent containers, and their properties such as Title and Id are used for display and navigation.",
   "Parameters": [
     {
       "Name": "Title",
@@ -25,13 +25,13 @@
       "Name": "Class",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the property to apply custom CSS styles."
+      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the Style property to apply custom CSS styles."
     },
     {
       "Name": "Style",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the property to apply CSS classes."
+      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the Class property to apply CSS classes."
     },
     {
       "Name": "Tag",

--- a/src/MudX.Docs/wwwroot/api/MudXSecurityCode.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXSecurityCode.api.json
@@ -7,7 +7,7 @@
       "Name": "Pattern",
       "Type": "String",
       "Default": "####",
-      "Description": "The pattern of the security code. e.g. (\u0022##/##/19##\u0022 would represent \u0022MM/DD/YYYY\u0022 where the first two YY are filled in.). Default Placeholders (can be changed)\u003E.# is a placeholder for a numeric value.A is a placeholder for an alphabetic character.? is a placeholder for an alphabetic or numeric character.@ is a placeholder for a special symbol.* is a placeholder for any UTF-8 character.\nRemarks: Defaults to \u0022####\u0022"
+      "Description": "The pattern of the security code. e.g. (\u0022##/##/19##\u0022 would represent \u0022MM/DD/YYYY\u0022 where the first two YY are filled in.). Default Placeholders (can be changed)\u003E. # is a placeholder for a numeric value. A is a placeholder for an alphabetic character. ? is a placeholder for an alphabetic or numeric character. @ is a placeholder for a special symbol. * is a placeholder for any UTF-8 character.\nRemarks: Defaults to \u0022####\u0022"
     },
     {
       "Name": "PlaceholderNumeric",
@@ -73,13 +73,13 @@
       "Name": "Variant",
       "Type": "Variant",
       "Default": "Outlined",
-      "Description": "The display variant of the component. Options are Outlined, Text, and Filled.\nRemarks: Defaults to"
+      "Description": "The display variant of the component. Options are Outlined, Text, and Filled.\nRemarks: Defaults to Outlined"
     },
     {
       "Name": "ReadOnlyVariant",
       "Type": "Variant",
       "Default": "Text",
-      "Description": "The display variant of the code when readonly. Options are Outlined, Text, and Filled.\nRemarks: Defaults to"
+      "Description": "The display variant of the code when readonly. Options are Outlined, Text, and Filled.\nRemarks: Defaults to Text"
     },
     {
       "Name": "Underline",
@@ -91,19 +91,19 @@
       "Name": "Margin",
       "Type": "Margin",
       "Default": "Normal",
-      "Description": "The margin of the component.\nRemarks: Defaults to"
+      "Description": "The margin of the component.\nRemarks: Defaults to Normal"
     },
     {
       "Name": "Class",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the property to apply custom CSS styles."
+      "Description": "The CSS classes applied to this component.\nRemarks: Defaults to null. You can use spaces to separate multiple classes. Use the Style property to apply custom CSS styles."
     },
     {
       "Name": "Style",
       "Type": "String",
       "Default": null,
-      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the property to apply CSS classes."
+      "Description": "The CSS styles applied to this component.\nRemarks: Defaults to null. Use the Class property to apply CSS classes."
     },
     {
       "Name": "Tag",

--- a/tests/MudX.UnitTests/DocsGenerator/ApiSourceTests.cs
+++ b/tests/MudX.UnitTests/DocsGenerator/ApiSourceTests.cs
@@ -10,12 +10,11 @@ public class ApiSourceTests
     {
         var xmlPath = Path.GetTempFileName();
         File.WriteAllText(xmlPath, """
-            <?xml version="1.0"?>
             <doc>
               <members>
                 <member name="P:Example.Component.Separator">
                   <summary>The separator shown between items.</summary>
-                  <remarks>Defaults to /. Will not be shown if <see cref="P:Example.Component.SeparatorTemplate" /> is set.</remarks>
+                  <remarks>Defaults to /. Will not be shown if <see cref="P:Example.Component.SeparatorTemplate" /> is set. Uses <see cref="T:System.String">custom text</see>.</remarks>
                 </member>
               </members>
             </doc>
@@ -32,7 +31,7 @@ public class ApiSourceTests
             var docs = (Dictionary<string, string>)loadXmlDocumentation.Invoke(null, [xmlPath])!;
 
             docs["P:Example.Component.Separator"].Should().Be(
-                "The separator shown between items.\nRemarks: Defaults to /. Will not be shown if SeparatorTemplate is set.");
+                "The separator shown between items.\nRemarks: Defaults to /. Will not be shown if SeparatorTemplate is set. Uses custom text.");
         }
         finally
         {

--- a/tests/MudX.UnitTests/DocsGenerator/ApiSourceTests.cs
+++ b/tests/MudX.UnitTests/DocsGenerator/ApiSourceTests.cs
@@ -22,7 +22,7 @@ public class ApiSourceTests
 
         try
         {
-            var apiSourceType = Assembly.Load("MudX.Docs.Generator")
+            var apiSourceType = Assembly.LoadFrom(GetDocsGeneratorAssemblyPath())
                 .GetType("MudX.Docs.Generator.ApiSource", throwOnError: true)!;
             var loadXmlDocumentation = apiSourceType.GetMethod(
                 "LoadXmlDocumentation",
@@ -37,5 +37,41 @@ public class ApiSourceTests
         {
             File.Delete(xmlPath);
         }
+    }
+
+    private static string GetDocsGeneratorAssemblyPath()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var testConfiguration = new DirectoryInfo(AppContext.BaseDirectory).Parent?.Name ?? "Debug";
+
+        return Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "MudX.Docs.Generator",
+            "bin",
+            testConfiguration,
+            "net10.0",
+            "MudX.Docs.Generator.dll");
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(
+                    directory.FullName,
+                    "src",
+                    "MudX.Docs.Generator",
+                    "MudX.Docs.Generator.csproj")))
+            {
+                return directory;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the MudX repository root.");
     }
 }

--- a/tests/MudX.UnitTests/DocsGenerator/ApiSourceTests.cs
+++ b/tests/MudX.UnitTests/DocsGenerator/ApiSourceTests.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using AwesomeAssertions;
+
+namespace MudX.UnitTests.DocsGenerator;
+
+public class ApiSourceTests
+{
+    [Fact]
+    public void LoadXmlDocumentation_PreservesReadableTextForSeeCrefElements()
+    {
+        var xmlPath = Path.GetTempFileName();
+        File.WriteAllText(xmlPath, """
+            <?xml version="1.0"?>
+            <doc>
+              <members>
+                <member name="P:Example.Component.Separator">
+                  <summary>The separator shown between items.</summary>
+                  <remarks>Defaults to /. Will not be shown if <see cref="P:Example.Component.SeparatorTemplate" /> is set.</remarks>
+                </member>
+              </members>
+            </doc>
+            """);
+
+        try
+        {
+            var apiSourceType = Assembly.Load("MudX.Docs.Generator")
+                .GetType("MudX.Docs.Generator.ApiSource", throwOnError: true)!;
+            var loadXmlDocumentation = apiSourceType.GetMethod(
+                "LoadXmlDocumentation",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            var docs = (Dictionary<string, string>)loadXmlDocumentation.Invoke(null, [xmlPath])!;
+
+            docs["P:Example.Component.Separator"].Should().Be(
+                "The separator shown between items.\nRemarks: Defaults to /. Will not be shown if SeparatorTemplate is set.");
+        }
+        finally
+        {
+            File.Delete(xmlPath);
+        }
+    }
+}

--- a/tests/MudX.UnitTests/MudX.UnitTests.csproj
+++ b/tests/MudX.UnitTests/MudX.UnitTests.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\MudX\MudX.csproj" />
-    <ProjectReference Include="..\..\src\MudX.Docs.Generator\MudX.Docs.Generator.csproj" />
+    <ProjectReference Include="..\..\src\MudX.Docs.Generator\MudX.Docs.Generator.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\MudX.UnitTests.Viewer\MudX.UnitTests.Viewer.csproj" />
   </ItemGroup>
 

--- a/tests/MudX.UnitTests/MudX.UnitTests.csproj
+++ b/tests/MudX.UnitTests/MudX.UnitTests.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\MudX\MudX.csproj" />
+    <ProjectReference Include="..\..\src\MudX.Docs.Generator\MudX.Docs.Generator.csproj" />
     <ProjectReference Include="..\MudX.UnitTests.Viewer\MudX.UnitTests.Viewer.csproj" />
   </ItemGroup>
 

--- a/tests/MudX.UnitTests/MudX.UnitTests.csproj
+++ b/tests/MudX.UnitTests/MudX.UnitTests.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\MudX\MudX.csproj" />
-    <ProjectReference Include="..\..\src\MudX.Docs.Generator\MudX.Docs.Generator.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\MudX.Docs.Generator\MudX.Docs.Generator.csproj" ReferenceOutputAssembly="false" Private="false" />
     <ProjectReference Include="..\MudX.UnitTests.Viewer\MudX.UnitTests.Viewer.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Gemini identified generated API documentation where inline XML doc references were being stripped from summaries and remarks, leaving broken text such as `Will not be shown if is set.` and `Defaults to .`. The docs generator now converts inline XML documentation tags into readable text before cleaning the API description output.

Related to #61

## Changes

- Preserve readable text for inline XML doc tags such as `<see cref>`, `<paramref>`, `<typeparamref>`, and `<see langword>`.
- Regenerate affected API JSON so omitted member/type names appear in the docs output.
- Add a regression test covering `<see cref>` inside XML documentation remarks.

## Before

Generated API text dropped inline references:

```text
Will not be shown if is set.
If is true and the number of items exceeds this value...
Defaults to . Displays when and the number of items exceeds .
```

## After

Generated API text keeps the referenced names:

```text
Will not be shown if SeparatorTemplate is set.
If Collapsed is true and the number of items exceeds this value...
Defaults to SettingsEthernet. Displays when Collapsed and the number of items exceeds MaxItems.
```

## Tested With

- `dotnet test tests/MudX.UnitTests/MudX.UnitTests.csproj --no-restore --filter "FullyQualifiedName~ApiSourceTests"`
- `dotnet test tests/MudX.UnitTests/MudX.UnitTests.csproj --no-restore`
- `dotnet build src/MudX.sln --no-restore`

## Notes

The solution build still reports existing warnings for obsolete `MudXSplitter`, MudBlazor analyzer `AutoGrow`, and one nullable test warning; no build errors were introduced.