### PR TITLE
Chat: Correct component names in API documentation

### DIFF
--- a/src/MudX.Docs/Components/Docs/Chat/ChatDocPage.razor
+++ b/src/MudX.Docs/Components/Docs/Chat/ChatDocPage.razor
@@ -71,7 +71,7 @@
                         <li>*<CodeInline Tag="false">Color</CodeInline>: The color of the chat bubbles. Defaults to <CodeInline>Color.Default</CodeInline>.</li>
                         <li>*<CodeInline Tag="false">Variant</CodeInline>: The variant of the chat bubbles. Defaults to <CodeInline>Variant.Text</CodeInline>.</li>
                     </ul>
-                    * These properties are passed down to the <CodeInline>MudChatBubble</CodeInline> components, and can be overridden individually.
+                    * These properties are passed down to the <CodeInline>MudXChatBubble</CodeInline> components, and can be overridden individually.
                 </Description>
             <ChildContent>
                 <SectionContent Codes="ChatFullExampleCode.Files">

--- a/src/MudX.Docs/wwwroot/api/MudXChat.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXChat.api.json
@@ -1,7 +1,7 @@
 {
   "Component": "MudXChat",
   "Namespace": "MudX",
-  "Description": "The MudXChat component is used to house one or more MudChatBubble components, with optional components such as MudAvatar, MudChatHeader, and MudChatFooter.",
+  "Description": "The MudXChat component is used to house one or more MudXChatBubble components, with optional components such as MudAvatar, MudXChatHeader, and MudXChatFooter.",
   "Parameters": [
     {
       "Name": "ArrowPosition",

--- a/src/MudX/Components/MudXChat/MudXChat.razor.cs
+++ b/src/MudX/Components/MudXChat/MudXChat.razor.cs
@@ -6,7 +6,7 @@ using MudX.Extensions;
 namespace MudX
 {
     /// <summary>
-    /// The MudXChat component is used to house one or more MudChatBubble components, with optional components such as MudAvatar, MudChatHeader, and MudChatFooter.
+    /// The MudXChat component is used to house one or more MudXChatBubble components, with optional components such as MudAvatar, MudXChatHeader, and MudXChatFooter.
     /// </summary>
     public partial class MudXChat : MudComponentBase
     {


### PR DESCRIPTION
## Summary

Correct stale Chat component names so the `MudXChat` XML summary, committed API metadata, and Chat docs prose consistently reference the current `MudXChatBubble`, `MudXChatHeader`, and `MudXChatFooter` components. Runtime and rendering behavior are unchanged.

## Changes

- Replace the three stale component names in the `MudXChat` XML summary.
- Regenerate only the matching `MudXChat.api.json` description.
- Replace the sole remaining `MudChatBubble` prose reference on the Chat docs page with `MudXChatBubble`.

## Tested With

- `dotnet format src/MudX/MudX.csproj --include src/MudX/Components/MudXChat/MudXChat.razor.cs --no-restore --verbosity minimal`
- `dotnet format src/MudX.Docs/MudX.Docs.csproj --include src/MudX.Docs/Components/Docs/Chat/ChatDocPage.razor --no-restore --verbosity minimal`
- `dotnet build src/MudX/MudX.csproj /p:SkipBunCompile=true --no-restore --nologo`
- `dotnet build src/MudX.Docs/MudX.Docs.csproj --no-restore --nologo`
- `! git grep -n -w -e MudChatBubble -e MudChatHeader -e MudChatFooter HEAD -- src`
- `git diff --check origin/dev...HEAD`

## Visual Evidence

Before: the Additional Chat Bubble Options example rendered the stale `<MudChatBubble>` name.

<img width="1280" height="900" alt="Before: stale MudChatBubble name" src="https://github.com/user-attachments/assets/40e2c941-bd75-4f4d-ba26-1f362b613b05" />

After: the same example renders the corrected `<MudXChatBubble>` public component name.

<img width="1280" height="900" alt="After: corrected MudXChatBubble name" src="https://github.com/user-attachments/assets/f85a248e-3c3a-4766-9823-300be55e2139" />

## Notes

- Repository-wide tracked-`src` verification confirms the stale whole identifiers are absent at head `4c1c4f7c2bbdb22034423685e6eec1c79e30930c`.
- The scoped builds complete with zero errors. Existing warnings in unrelated `MudXSecurityCode`, `MudXSheet`, and Sheet docs example code remain outside this change.

-- Coded by Codebringer / AI
-- Codebringer for versile2
-- versile2 approved
