### PR TITLE
Chat: Document accessible live transcripts

### DIFF
--- a/src/MudX.Docs/Components/Docs/Chat/ChatDocPage.razor
+++ b/src/MudX.Docs/Components/Docs/Chat/ChatDocPage.razor
@@ -25,6 +25,17 @@
             </ChildContent>
         </DocsPageSection>
 
+        <DocsPageSection Title="Accessibility">
+            <Description>
+                For a transcript that receives new messages, place <CodeInline Tag="false">role="log"</CodeInline>, <CodeInline Tag="false">aria-live="polite"</CodeInline>, and <CodeInline Tag="false">aria-relevant="additions"</CodeInline> on one outer transcript container. The transcript owner provides the accessible name and live-region semantics; each <CodeInline>MudXChat</CodeInline> remains a message group within it.
+            </Description>
+            <ChildContent>
+                <SectionContent Codes="@ChatTranscriptAccessibilityExampleCode.Files">
+                    <ChatTranscriptAccessibilityExample />
+                </SectionContent>
+            </ChildContent>
+        </DocsPageSection>
+
         <DocsPageSection Title="With Avatar">
                 <Description>
                     MudXChat can include an avatar, which works seamlessly with the <CodeInline>MudAvatar</CodeInline> component. The avatar will always appear on the first <CodeInline>MudXChatBubble</CodeInline> inside a MudXChat. 

--- a/src/MudX.Docs/Components/Docs/Chat/Examples/ChatTranscriptAccessibilityExample.razor
+++ b/src/MudX.Docs/Components/Docs/Chat/Examples/ChatTranscriptAccessibilityExample.razor
@@ -1,0 +1,16 @@
+@namespace MudX.Docs.Chat
+
+<div role="log"
+     aria-live="polite"
+     aria-relevant="additions"
+     aria-label="Conversation transcript">
+    <MudXChat ChatPosition="MudX.ChatBubblePosition.Start">
+        <MudXChatHeader Name="Obi-Wan Kenobi" Time="2 hours ago" />
+        <MudXChatBubble>You were my brother Anakin.</MudXChatBubble>
+    </MudXChat>
+
+    <MudXChat ChatPosition="MudX.ChatBubblePosition.End">
+        <MudXChatHeader Name="Anakin Skywalker" Time="1 hour ago" />
+        <MudXChatBubble>I'm sorry.</MudXChatBubble>
+    </MudXChat>
+</div>

--- a/src/MudX.Docs/Components/Examples/ChatTranscriptAccessibilityExample.g.cs
+++ b/src/MudX.Docs/Components/Examples/ChatTranscriptAccessibilityExample.g.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using MudX;
+
+namespace MudX.Docs.Examples
+{
+    public static class ChatTranscriptAccessibilityExampleCode
+    {
+        public static readonly IEnumerable<CodeFile> Files = new[]
+        {
+            new CodeFile
+            (
+                Title: "ChatTranscriptAccessibilityExample.razor",
+                Code: @"@namespace MudX.Docs.Chat
+
+<div role=""log""
+     aria-live=""polite""
+     aria-relevant=""additions""
+     aria-label=""Conversation transcript"">
+    <MudXChat ChatPosition=""MudX.ChatBubblePosition.Start"">
+        <MudXChatHeader Name=""Obi-Wan Kenobi"" Time=""2 hours ago"" />
+        <MudXChatBubble>You were my brother Anakin.</MudXChatBubble>
+    </MudXChat>
+
+    <MudXChat ChatPosition=""MudX.ChatBubblePosition.End"">
+        <MudXChatHeader Name=""Anakin Skywalker"" Time=""1 hour ago"" />
+        <MudXChatBubble>I'm sorry.</MudXChatBubble>
+    </MudXChat>
+</div>
+",
+                Language: CodeLanguage.Razor
+            )
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Document how to compose `MudXChat` message groups inside one accessible live transcript. The transcript container owns the accessible name and live-region semantics, avoiding duplicate announcements from marking every message group as a separate live region.

## Changes

- Add an Accessibility section to the Chat documentation.
- Add a focused transcript example with two `MudXChat` message groups inside one named `role="log"` container.
- Commit the matching generated example source.

## Semantic Evidence

- The source and generated example each contain exactly one `role="log"`, one `aria-live="polite"`, and one `aria-relevant="additions"` owner.
- The live transcript contains two `MudXChat` message groups.
- `MudXChat` component source remains free of default live-region attributes.

## Tested With

- `dotnet format src/MudX.Docs/MudX.Docs.csproj --include src/MudX.Docs/Components/Docs/Chat/ChatDocPage.razor src/MudX.Docs/Components/Docs/Chat/Examples/ChatTranscriptAccessibilityExample.razor src/MudX.Docs/Components/Examples/ChatTranscriptAccessibilityExample.g.cs --no-restore --verbosity minimal`
- `dotnet build src/MudX.Docs/MudX.Docs.csproj --no-restore --nologo`
- Focused source/generated occurrence-count assertions for the transcript attributes and message groups.
- `git diff --check origin/dev...HEAD`

## Visual Evidence

Before: the Chat docs had no Accessibility section or transcript composition example.

<img width="1280" height="900" alt="Before: Chat docs without Accessibility section" src="https://github.com/user-attachments/assets/e5b91fe4-9dcf-42cb-b00b-06a28452d189" />

After: the Chat docs render the new Accessibility guidance and transcript example. The source/generated semantic checks above prove the single named `role="log"` owner.

<img width="1280" height="900" alt="After: Chat Accessibility section and transcript example" src="https://github.com/user-attachments/assets/c6a03723-dd30-472c-a775-48d07a1164f0" />

## Notes

- This changes documentation and example semantics only; it does not add component defaults, rendering behavior, a transcript component, or JavaScript.
- The docs build completes with zero errors. Existing warnings in unrelated `MudXSecurityCode`, `MudXSheet`, and Sheet docs example code remain outside this change.

-- Coded by Codebringer / AI
-- Codebringer for versile2
-- versile2 approved
