### PR TITLE
Sheet: Correct the documented preset sizes

### DIFF
--- a/src/MudX.Docs/wwwroot/api/MudXSheet.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXSheet.api.json
@@ -103,7 +103,7 @@
       "Name": "PresetSizes",
       "Type": "Int32[]",
       "Default": "[25, 50, 75, ...]",
-      "Description": "List of snap point heights (in viewport height or width) to toggle or drag\nRemarks: Defaults to [20, 40, 50, 70, 90, 100]. Valid values are between 10 and 100, inclusive."
+      "Description": "List of snap point heights (in viewport height or width) to toggle or drag\nRemarks: Defaults to [25, 50, 75, 100]. Valid values are between 10 and 100, inclusive."
     },
     {
       "Name": "SheetHandleFragment",

--- a/src/MudX/Components/MudXSheet/MudXSheet.razor.cs
+++ b/src/MudX/Components/MudXSheet/MudXSheet.razor.cs
@@ -284,7 +284,7 @@ public partial class MudXSheet : MudComponentBase, IAsyncDisposable
     /// List of snap point heights (in viewport height or width) to toggle or drag
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>[20, 40, 50, 70, 90, 100]</c>.<br/>
+    /// Defaults to <c>[25, 50, 75, 100]</c>.<br/>
     /// Valid values are between 10 and 100, inclusive.<br/>
     /// </remarks>
     [Parameter]


### PR DESCRIPTION
## Summary

Correct the `MudXSheet.PresetSizes` documentation so it matches the existing `[25, 50, 75, 100]` initializer. The source remarks and committed API description now agree; sheet behavior and defaults are unchanged.

## Changes

- Replace the stale preset-size list in the `PresetSizes` XML remarks.
- Regenerate only the matching `MudXSheet.api.json` description.

## Tested With

- `dotnet format src/MudX/MudX.csproj --include src/MudX/Components/MudXSheet/MudXSheet.razor.cs --no-restore --verbosity minimal`
- `dotnet build src/MudX/MudX.csproj /p:SkipBunCompile=true --no-restore --nologo`
- `dotnet build src/MudX.Docs/MudX.Docs.csproj --no-restore --nologo`
- Verified source remarks, initializer, and generated API description contain `[25, 50, 75, 100]`.
- Verified the stale `[20, 40, 50, 70, 90, 100]` list is absent from the changed source/API files.
- Verified `Standard` remains initialized to `true`.
- `git diff --check origin/dev...HEAD`

## Visual Evidence

Before at base `551ea8ec29f336f6d7771fe34ba8f808f55124d8`: the rendered API row said `Defaults to [20, 40, 50, 70, 90, 100].`.

<img width="1280" height="900" alt="Before: stale PresetSizes API description" src="https://github.com/user-attachments/assets/e5396f9b-0e29-4906-88a0-c010453a5c1e" />

After at head `8705e52ab8b26000790bcc411915d8d25d3c0548`: the rendered row says `Defaults to [25, 50, 75, 100].`.

<img width="1280" height="900" alt="After: corrected PresetSizes API description" src="https://github.com/user-attachments/assets/a9307fe1-a714-4163-9c71-1dd17a312fa9" />

## Notes

- The generated API model intentionally abbreviates the structural array preview as `[25, 50, 75, ...]`; the adjacent full description now reports all four actual values.
- The scoped builds complete with zero errors. Existing warnings in unrelated `MudXSecurityCode`, `MudXSheet`, and Sheet docs example code remain outside this change.

-- Coded by Codebringer / AI
-- Codebringer for versile2
-- versile2 approved
