### PR TITLE
Docs: Improve Sheet, IdMasker, and SecurityCode discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@
 
 ## Table of Contents
 - [MudXSecurityCode](#mudxsecuritycode)
+- [MudXSheet](#mudxsheet)
 - [MudXChat](#mudxchat)
 - [MudXOutline](#mudxoutline)
 - [MudXCodeBlock](#mudxcodeblock)
 - [MudXCopyToClipboard](#mudxcopytoclipboard)
 - [MudXBreadcrumbs](#mudxbreadcrumbs)
 - [Blazor Lottie Player](#blazor-lottie-player)]
+- [IdMasker](#idmasker)
 
 ---
 
@@ -38,8 +40,18 @@ A component for creating a chat interface with customizable MudXChatBubble compo
 ### MudXSecurityCode
 ![status](https://img.shields.io/badge/status-new-red)
 
-A component for entering security codes, such as SMS or email verification codes.  
+A segmented input component for security codes, such as SMS or email verification codes. Configurable placeholders and fixed characters also support segmented pattern masks for values such as dates and formatted identifiers.
+
 ![MudXSecurityCode Image](https://github.com/MudXtra/Mudx/raw/dev/images/MudXSecurityCode.png)  
+[Back to top](#table-of-contents)
+
+---
+
+### MudXSheet
+![status](https://img.shields.io/badge/status-new-red)
+
+A sheet component that displays contextual content from the top, bottom, left, right, or center of the screen for mobile and desktop layouts.
+
 [Back to top](#table-of-contents)
 
 ---
@@ -86,4 +98,14 @@ A self-navigating breadcrumb navigation component that supports custom separator
 A Blazor component for rendering Lottie animations, downloadable separately from MudX but designed and
 maintained by the MudX team.
 ![Blazor Lottie Player Image](https://github.com/MudXtra/Mudx/raw/dev/images/BlazorLottiePlayer.png)  
+[Back to top](#table-of-contents)
+
+---
+
+## Utilities
+
+### IdMasker
+
+A static utility for creating human-friendly obfuscated IDs with `IdMasker.MaskId` and restoring them with `IdMasker.UnMaskId`. The masked values are not cryptographically secure.
+
 [Back to top](#table-of-contents)


### PR DESCRIPTION
## Summary

The README did not surface `MudXSheet` or the public `IdMasker` utility, and described `MudXSecurityCode` only as a verification-code input. This change makes all three capabilities directly discoverable while preserving the existing README structure.

## Changes

- Add table-of-contents links and concise sections for `MudXSheet` and `IdMasker`.
- Describe `IdMasker` with its exact public `MaskId` and `UnMaskId` methods and its non-cryptographic boundary.
- Clarify that `MudXSecurityCode` supports configurable segmented pattern masks through placeholders and fixed characters.

## Tested With

- Verified each required table-of-contents link has exactly one matching Markdown heading.
- Verified `src/MudX/Components/MudXIdMasker/IdMasker.cs` declares `public static class IdMasker` and the documented `MaskId` and `UnMaskId` methods.
- Verified `README.md` does not use the incorrect `MudXIdMasker` name.
- `git diff --check 551ea8ec29f336f6d7771fe34ba8f808f55124d8..a965a5cb73a06b7d51a89dd8234048fb0da61cdd`

## Visual Evidence

Before: the README table of contents did not expose `MudXSheet` or `IdMasker`.

<img width="1280" height="900" alt="Before: README table of contents without MudXSheet or IdMasker" src="https://github.com/user-attachments/assets/f77ae88c-155e-40f8-8c4c-23761828a8a6" />

After: both capabilities are directly linked from the table of contents.

<img width="1280" height="900" alt="After: README table of contents with MudXSheet and IdMasker" src="https://github.com/user-attachments/assets/d14f56d9-2ae3-4e67-b585-d37c8fcd75a9" />

The new rendered `MudXSheet` discovery section:

<img width="1280" height="900" alt="After: rendered MudXSheet README section" src="https://github.com/user-attachments/assets/fbb62c63-2fa7-48ff-86c5-0060fa8b1752" />

The new rendered `IdMasker` section, including its reversible non-cryptographic boundary:

<img width="1280" height="900" alt="After: rendered IdMasker README section" src="https://github.com/user-attachments/assets/2a3a8e39-13c4-4caf-b7e9-297bea7058ad" />

## Notes

This is a README-only documentation change and does not alter runtime behavior.

-- Coded by Codebringer / AI
-- Codebringer for versile2
-- versile2 approved
