### PR TITLE
Docs: Identify the active MudX NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@
 ## Getting started with MudX is easy:
 
 1. **Step 1:** Install [MudBlazor](https://mudblazor.com/getting-started/installation).
-2. **Step 2:** Add MudX to your project via NuGet.
+2. **Step 2:** Add the active MudX package via NuGet:
+
+   ```shell
+   dotnet add package MudX.MudBlazor.Extension
+   ```
+
+   > **Note:** The plural `MudX.MudBlazor.Extensions` package ID is an older package line and is not the active package documented by this repository.
 3. **Step 3:** Include the `MudXProvider` in your layout **-or-** reference `./_content/MudX.MudBlazor.Extension/_mudx.min.css` and `./_content/MudX.MudBlazor.Extension/mudx.min.js` in your project **-with-** cache busting.
 4. **Step 4:** Start using components - all MudX components are prefixed with `MudX`, such as `MudXOutline`.
 5. **Step 5:** Browse the [documentation](https://mudx.org) to learn how to use each component.


### PR DESCRIPTION
## Summary

Identify `MudX.MudBlazor.Extension` as the active NuGet package, provide the exact installation command, and distinguish the obsolete plural package line so users do not install the wrong package.

## Changes

- Document the active NuGet package ID as `MudX.MudBlazor.Extension`.
- Add the exact `dotnet add package MudX.MudBlazor.Extension` command.
- Clarify that `MudX.MudBlazor.Extensions` belongs to an older package line and is not the active package documented by this repository.

## Visual Evidence

Before - GitHub-rendered Getting Started section at 1280x900: the README only said to add MudX through NuGet and did not identify the package.

<img width="1280" height="900" alt="Before: Getting Started section without the active NuGet package ID" src="https://github.com/user-attachments/assets/f5f14221-a4d2-4a97-9aa4-246fd135c4e3" />

After - GitHub-rendered Getting Started section at 1280x900: the README shows the exact singular package command and explains the older plural package line.

<img width="1280" height="900" alt="After: Getting Started section with the active singular package command" src="https://github.com/user-attachments/assets/34b95fd9-aa14-4ec1-a3f4-2d4b511c305c" />

## Tested With

- Confirmed `src/MudX/MudX.csproj` declares `<PackageId>MudX.MudBlazor.Extension</PackageId>`.
- Confirmed the final diff changes only `README.md`.
- Confirmed the singular package is the current listed NuGet line and the plural package is an older unlisted line.
- Verified the rendered command block, note nesting, and ordered-list continuation in GitHub at 1280x900.
- `git diff --check origin/dev...HEAD`
- Build/tests not run: this is a README-only change with no source or package metadata changes; GitHub build and coverage checks passed at the reviewed head.

## Notes

- Preserve the approved sequence: incorporate PR #72 first, then update/rebase and revalidate this PR against the resulting README state before incorporation.
- This change does not modify package metadata, package versions, releases, or external package listings.

-- Coded by Codebringer / AI
-- Codebringer for versile2
-- versile2 approved
