### PR TITLE
SecurityCode: Add accessible form state

### DIFF
--- a/src/MudX.Docs/Components/Docs/SecurityCode/Examples/SecurityCodeFormStateExample.razor
+++ b/src/MudX.Docs/Components/Docs/SecurityCode/Examples/SecurityCodeFormStateExample.razor
@@ -1,0 +1,23 @@
+@namespace MudX.Docs.SecurityCode
+
+<MudStack Spacing="2">
+    <MudStack Row="true">
+        <MudSwitch @bind-Value="_disabled" Color="Color.Primary">Disabled</MudSwitch>
+        <MudSwitch @bind-Value="_error" Color="Color.Error">Error</MudSwitch>
+    </MudStack>
+
+    <MudXSecurityCode @bind-Code="_code"
+                      Label="Verification code"
+                      HelperText="Enter the four-digit code from your authenticator."
+                      Required="true"
+                      Disabled="_disabled"
+                      Error="_error"
+                      ErrorText="The verification code is invalid."
+                      AriaLabel="Account verification code" />
+</MudStack>
+
+@code {
+    private string? _code;
+    private bool _disabled;
+    private bool _error;
+}

--- a/src/MudX.Docs/Components/Docs/SecurityCode/SecurityCodeDocPage.razor
+++ b/src/MudX.Docs/Components/Docs/SecurityCode/SecurityCodeDocPage.razor
@@ -43,7 +43,10 @@
                 <CodeInline Tag="false">ErrorText</CodeInline> to describe the segmented control once as one logical field.
                 <CodeInline Tag="false">Required</CodeInline>, <CodeInline Tag="false">Disabled</CodeInline>, and
                 <CodeInline Tag="false">Error</CodeInline> expose the corresponding field state. Use
-                <CodeInline Tag="false">AriaLabel</CodeInline> when the accessible name should differ from the visible label.
+                <CodeInline Tag="false">AriaLabel</CodeInline> when the group name should differ from the visible label, and
+                <CodeInline Tag="false">SegmentAriaLabelFormat</CodeInline> to localize the ordinal names announced for editable segments.
+                An <CodeInline Tag="false">aria-label</CodeInline> supplied through <CodeInline Tag="false">UserAttributes</CodeInline>
+                takes precedence over the segment format.
             </Description>
             <ChildContent>
                 <SectionContent Codes="@SecurityCodeFormStateExampleCode.Files">

--- a/src/MudX.Docs/Components/Docs/SecurityCode/SecurityCodeDocPage.razor
+++ b/src/MudX.Docs/Components/Docs/SecurityCode/SecurityCodeDocPage.razor
@@ -46,7 +46,7 @@
                 <CodeInline Tag="false">AriaLabel</CodeInline> when the group name should differ from the visible label, and
                 <CodeInline Tag="false">SegmentAriaLabelFormat</CodeInline> to localize the ordinal names announced for editable segments.
                 An <CodeInline Tag="false">aria-label</CodeInline> supplied through <CodeInline Tag="false">UserAttributes</CodeInline>
-                takes precedence over the segment format.
+                takes precedence over the segment format without replacing the group name.
             </Description>
             <ChildContent>
                 <SectionContent Codes="@SecurityCodeFormStateExampleCode.Files">

--- a/src/MudX.Docs/Components/Docs/SecurityCode/SecurityCodeDocPage.razor
+++ b/src/MudX.Docs/Components/Docs/SecurityCode/SecurityCodeDocPage.razor
@@ -37,6 +37,21 @@
             </ChildContent>
         </DocsPageSection>
 
+        <DocsPageSection Title="Form state and accessibility">
+            <Description>
+                Use <CodeInline Tag="false">Label</CodeInline>, <CodeInline Tag="false">HelperText</CodeInline>, and
+                <CodeInline Tag="false">ErrorText</CodeInline> to describe the segmented control once as one logical field.
+                <CodeInline Tag="false">Required</CodeInline>, <CodeInline Tag="false">Disabled</CodeInline>, and
+                <CodeInline Tag="false">Error</CodeInline> expose the corresponding field state. Use
+                <CodeInline Tag="false">AriaLabel</CodeInline> when the accessible name should differ from the visible label.
+            </Description>
+            <ChildContent>
+                <SectionContent Codes="@SecurityCodeFormStateExampleCode.Files">
+                    <SecurityCodeFormStateExample />
+                </SectionContent>
+            </ChildContent>
+        </DocsPageSection>
+
         <DocsPageSection Title="Orientation">
             <Description>
                 There are several different orientation styles that can be applied to the <CodeInline>MudXSecurityCode</CodeInline> control.
@@ -72,7 +87,7 @@
             <Description>
                 The browser <CodeInline Tag="false">Paste</CodeInline> command allows you to insert the current value from your clipboard into the
                 <CodeInline>MudXSecurityCode</CodeInline> component. Using a lightweight algorithm, it attempts to intelligently place your
-                pasted value—regardless of whether it includes read-only characters or the position where you start pasting.
+                pasted valueâ€”regardless of whether it includes read-only characters or the position where you start pasting.
 
                 Try copying the example text below and pasting it into the component. Additionally, the <CodeInline>Code</CodeInline> parameter
                 is two-way bound, so it updates as you type and also reflects changes made externally, as if a paste began at position 0.

--- a/src/MudX.Docs/Components/Examples/SecurityCodeFormStateExample.g.cs
+++ b/src/MudX.Docs/Components/Examples/SecurityCodeFormStateExample.g.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using MudX;
+
+namespace MudX.Docs.Examples
+{
+    public static class SecurityCodeFormStateExampleCode
+    {
+        public static readonly IEnumerable<CodeFile> Files = new[]
+        {
+            new CodeFile
+            (
+                Title: "SecurityCodeFormStateExample.razor",
+                Code: @"@namespace MudX.Docs.SecurityCode
+
+<MudStack Spacing=""2"">
+    <MudStack Row=""true"">
+        <MudSwitch @bind-Value=""_disabled"" Color=""Color.Primary"">Disabled</MudSwitch>
+        <MudSwitch @bind-Value=""_error"" Color=""Color.Error"">Error</MudSwitch>
+    </MudStack>
+
+    <MudXSecurityCode @bind-Code=""_code""
+                      Label=""Verification code""
+                      HelperText=""Enter the four-digit code from your authenticator.""
+                      Required=""true""
+                      Disabled=""_disabled""
+                      Error=""_error""
+                      ErrorText=""The verification code is invalid.""
+                      AriaLabel=""Account verification code"" />
+</MudStack>
+
+@code {
+    private string? _code;
+    private bool _disabled;
+    private bool _error;
+}
+",
+                Language: CodeLanguage.Razor
+            )
+        };
+    }
+}

--- a/src/MudX.Docs/wwwroot/api/MudXSecurityCode.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXSecurityCode.api.json
@@ -124,6 +124,12 @@
       "Description": "Whether a value is required for every editable segment.\nRemarks: Defaults to false."
     },
     {
+      "Name": "SegmentAriaLabelFormat",
+      "Type": "String",
+      "Default": "Character {0} of {1}",
+      "Description": "The format used for each editable segment\u0027s accessible name.\nRemarks: Defaults to \u0022Character {0} of {1}\u0022, where {0} is the segment position and {1} is the editable segment count. An aria-label supplied through UserAttributes takes precedence."
+    },
+    {
       "Name": "Spacing",
       "Type": "Int32",
       "Default": "2",

--- a/src/MudX.Docs/wwwroot/api/MudXSecurityCode.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXSecurityCode.api.json
@@ -4,6 +4,12 @@
   "Description": "Represents a security code input component that allows users to enter a code based on a specified pattern.",
   "Parameters": [
     {
+      "Name": "AriaLabel",
+      "Type": "String",
+      "Default": "null",
+      "Description": "The accessible name for the security code group.\nRemarks: Defaults to null. When set, this value takes precedence over Label for the group\u0027s accessible name."
+    },
+    {
       "Name": "Class",
       "Type": "String",
       "Default": null,
@@ -22,10 +28,40 @@
       "Description": "Called when the value of the security code changes."
     },
     {
+      "Name": "Disabled",
+      "Type": "Boolean",
+      "Default": "false",
+      "Description": "Whether the editable security code segments are disabled.\nRemarks: Defaults to false."
+    },
+    {
+      "Name": "Error",
+      "Type": "Boolean",
+      "Default": "false",
+      "Description": "Whether the security code group is in an error state.\nRemarks: Defaults to false."
+    },
+    {
+      "Name": "ErrorText",
+      "Type": "String",
+      "Default": "null",
+      "Description": "The error text displayed when Error is true.\nRemarks: Defaults to null."
+    },
+    {
+      "Name": "HelperText",
+      "Type": "String",
+      "Default": "null",
+      "Description": "The helper text displayed beneath the security code group.\nRemarks: Defaults to null."
+    },
+    {
       "Name": "Horizontal",
       "Type": "Boolean",
       "Default": "true",
       "Description": "Whether to display items horizontally, if true will display items horizontally, false will display items vertically\nRemarks: Defaults to true."
+    },
+    {
+      "Name": "Label",
+      "Type": "String",
+      "Default": "null",
+      "Description": "The visible label for the security code group.\nRemarks: Defaults to null."
     },
     {
       "Name": "Margin",
@@ -82,6 +118,12 @@
       "Description": "The display variant of the code when readonly. Options are Outlined, Text, and Filled.\nRemarks: Defaults to Text"
     },
     {
+      "Name": "Required",
+      "Type": "Boolean",
+      "Default": "false",
+      "Description": "Whether a value is required for every editable segment.\nRemarks: Defaults to false."
+    },
+    {
       "Name": "Spacing",
       "Type": "Int32",
       "Default": "2",
@@ -135,7 +177,7 @@
           "Type": "String"
         }
       ],
-      "Description": "Handles the clipboard paste event triggered in javascript by processing the pasted text and updating the corresponding code items.\nRemarks: This method processes the pasted text by matching it against the editable and fixed characters in the code items. Editable code items are updated with valid characters from the pasted text, while fixed code items are set to their predefined values. After processing, the method updates the code value, moves focus to the next focusable item, and validates the form if applicable."
+      "Description": "Handles the clipboard paste event triggered in javascript by processing the pasted text and updating the corresponding code items.\nRemarks: This method processes the pasted text by matching it against the editable and fixed characters in the code items. Editable code items are updated with valid characters from the pasted text, while fixed code items are set to their predefined values. After processing, the method updates the code value, moves focus to the next focusable item, and runs the component\u0027s internal segmented-field validation."
     }
   ]
 }

--- a/src/MudX.Docs/wwwroot/api/MudXSecurityCode.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXSecurityCode.api.json
@@ -127,7 +127,7 @@
       "Name": "SegmentAriaLabelFormat",
       "Type": "String",
       "Default": "Character {0} of {1}",
-      "Description": "The format used for each editable segment\u0027s accessible name.\nRemarks: Defaults to \u0022Character {0} of {1}\u0022, where {0} is the segment position and {1} is the editable segment count. An aria-label supplied through UserAttributes takes precedence. Null, blank, or malformed formats fall back to the default so every editable segment remains named."
+      "Description": "The format used for each editable segment\u0027s accessible name.\nRemarks: Defaults to \u0022Character {0} of {1}\u0022, where {0} is the segment position and {1} is the editable segment count. An aria-label supplied through UserAttributes labels each editable segment and takes precedence. It does not replace the group\u0027s accessible name. Null, blank, or malformed formats fall back to the default so every editable segment remains named."
     },
     {
       "Name": "Spacing",

--- a/src/MudX.Docs/wwwroot/api/MudXSecurityCode.api.json
+++ b/src/MudX.Docs/wwwroot/api/MudXSecurityCode.api.json
@@ -127,7 +127,7 @@
       "Name": "SegmentAriaLabelFormat",
       "Type": "String",
       "Default": "Character {0} of {1}",
-      "Description": "The format used for each editable segment\u0027s accessible name.\nRemarks: Defaults to \u0022Character {0} of {1}\u0022, where {0} is the segment position and {1} is the editable segment count. An aria-label supplied through UserAttributes takes precedence."
+      "Description": "The format used for each editable segment\u0027s accessible name.\nRemarks: Defaults to \u0022Character {0} of {1}\u0022, where {0} is the segment position and {1} is the editable segment count. An aria-label supplied through UserAttributes takes precedence. Null, blank, or malformed formats fall back to the default so every editable segment remains named."
     },
     {
       "Name": "Spacing",

--- a/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor
+++ b/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor
@@ -3,7 +3,22 @@
 
 @((MarkupString)ContainerClass)
 
-<div @ref="@_elementRef" id="@Id" class="@($"mudx-code-container {Class}")" @attributes="@UserAttributes">
+<div @ref="@_elementRef"
+     id="@Id"
+     class="@($"mudx-code-container {Class}")"
+     role="group"
+     aria-label="@(!string.IsNullOrWhiteSpace(AriaLabel) ? AriaLabel : null)"
+     aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) && !string.IsNullOrWhiteSpace(Label) ? LabelId : null)"
+     aria-describedby="@DescribedBy"
+     aria-required="@(Required ? "true" : null)"
+     aria-invalid="@(Error ? "true" : null)"
+     aria-disabled="@(Disabled ? "true" : null)"
+     @attributes="@UserAttributes">
+    @if (!string.IsNullOrWhiteSpace(Label))
+    {
+        <label id="@LabelId" class="mudx-code-label">@Label</label>
+    }
+
     <MudForm @ref="@_form">
         <MudStack Row="@Horizontal"
         Justify="Justify.SpaceBetween"
@@ -25,9 +40,20 @@
                               Margin="@Margin"
                               Underline="@(item.IsEditable ? Underline : false)"
                               OnKeyDown="@(e => OnKeyDown(item.Index, e))"
+                              Disabled="@(item.IsEditable && Disabled)"
                               ReadOnly="!item.IsEditable" />
             }
 
         </MudStack>
     </MudForm>
+
+    @if (!string.IsNullOrWhiteSpace(HelperText))
+    {
+        <div id="@HelperTextId" class="mudx-code-helper-text">@HelperText</div>
+    }
+
+    @if (Error && !string.IsNullOrWhiteSpace(ErrorText))
+    {
+        <div id="@ErrorTextId" class="mudx-code-error-text">@ErrorText</div>
+    }
 </div>

--- a/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor
+++ b/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor
@@ -10,10 +10,10 @@
      aria-label="@(!string.IsNullOrWhiteSpace(AriaLabel) ? AriaLabel : null)"
      aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) && !string.IsNullOrWhiteSpace(Label) ? LabelId : null)"
      aria-disabled="@(Disabled ? "true" : null)"
-     @attributes="@UserAttributes">
+     @attributes="@GetContainerAttributes()">
     @if (!string.IsNullOrWhiteSpace(Label))
     {
-        <label id="@LabelId" class="mudx-code-label">@Label</label>
+        <label id="@LabelId" for="@FirstEditableInputId" class="mudx-code-label">@Label</label>
     }
 
     <MudForm @ref="@_form">

--- a/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor
+++ b/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor
@@ -9,9 +9,6 @@
      role="group"
      aria-label="@(!string.IsNullOrWhiteSpace(AriaLabel) ? AriaLabel : null)"
      aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) && !string.IsNullOrWhiteSpace(Label) ? LabelId : null)"
-     aria-describedby="@DescribedBy"
-     aria-required="@(Required ? "true" : null)"
-     aria-invalid="@(Error ? "true" : null)"
      aria-disabled="@(Disabled ? "true" : null)"
      @attributes="@UserAttributes">
     @if (!string.IsNullOrWhiteSpace(Label))
@@ -21,8 +18,9 @@
 
     <MudForm @ref="@_form">
         <MudStack Row="@Horizontal"
-        Justify="Justify.SpaceBetween"
-        Spacing="@Spacing">
+                  Justify="Justify.SpaceBetween"
+                  Spacing="@Spacing"
+                  role="presentation">
 
             @foreach (var item in CodeItems.OrderBy(x => x.Index))
             {                
@@ -33,13 +31,16 @@
                               @bind-Value:after="@(() => OnAfterChange(item.Index))"
                               Immediate="true"
                               Validation="@((string val) => CharPatternValidator(item.Index, val))"
-                              UserAttributes="@_attributes"
+                              UserAttributes="@GetInputAttributes(item)"
                               InputType="@(item.IsEditable && Password ? InputType.Password : InputType.Text)"
                               InputMode="@(item.PatternChar == PlaceholderNumeric ? InputMode.numeric : InputMode.text)"
                               Variant="@(!item.IsEditable ? ReadOnlyVariant : Variant)"
                               Margin="@Margin"
                               Underline="@(item.IsEditable ? Underline : false)"
                               OnKeyDown="@(e => OnKeyDown(item.Index, e))"
+                              Required="@(item.IsEditable && Required)"
+                              Error="@(item.IsEditable && Error)"
+                              HelperId="@GetDescriptionIds(item)"
                               Disabled="@(item.IsEditable && Disabled)"
                               ReadOnly="!item.IsEditable" />
             }
@@ -54,6 +55,6 @@
 
     @if (Error && !string.IsNullOrWhiteSpace(ErrorText))
     {
-        <div id="@ErrorTextId" class="mudx-code-error-text">@ErrorText</div>
+        <div id="@ErrorTextId" class="mudx-code-error-text" role="alert">@ErrorText</div>
     }
 </div>

--- a/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor.cs
+++ b/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor.cs
@@ -24,6 +24,7 @@ namespace MudX
         private string LabelId => $"{Id}-label";
         private string HelperTextId => $"{Id}-helper-text";
         private string ErrorTextId => $"{Id}-error-text";
+        private const string DefaultSegmentAriaLabelFormat = "Character {0} of {1}";
 
         private Dictionary<string, object?> GetInputAttributes(CodeItem item)
         {
@@ -35,7 +36,7 @@ namespace MudX
                 var ordinal = CodeItems.Take(item.Index + 1).Count(codeItem => codeItem.IsEditable);
                 var total = CodeItems.Count(codeItem => codeItem.IsEditable);
                 if (!hasExplicitAriaLabel)
-                    attributes["aria-label"] = string.Format(CultureInfo.CurrentCulture, SegmentAriaLabelFormat, ordinal, total);
+                    attributes["aria-label"] = FormatSegmentAriaLabel(ordinal, total);
             }
             else
             {
@@ -45,6 +46,21 @@ namespace MudX
             }
 
             return attributes;
+        }
+
+        private string FormatSegmentAriaLabel(int ordinal, int total)
+        {
+            var format = string.IsNullOrWhiteSpace(SegmentAriaLabelFormat)
+                ? DefaultSegmentAriaLabelFormat
+                : SegmentAriaLabelFormat;
+            try
+            {
+                return string.Format(CultureInfo.CurrentCulture, format, ordinal, total);
+            }
+            catch (FormatException)
+            {
+                return string.Format(CultureInfo.CurrentCulture, DefaultSegmentAriaLabelFormat, ordinal, total);
+            }
         }
 
         private string? GetDescriptionIds(CodeItem item)
@@ -213,9 +229,10 @@ namespace MudX
         /// <remarks>
         /// Defaults to <c>"Character {0} of {1}"</c>, where <c>{0}</c> is the segment position and <c>{1}</c> is the editable segment count.
         /// An <c>aria-label</c> supplied through <see cref="MudComponentBase.UserAttributes" /> takes precedence.
+        /// Null, blank, or malformed formats fall back to the default so every editable segment remains named.
         /// </remarks>
         [Parameter]
-        public string SegmentAriaLabelFormat { get; set; } = "Character {0} of {1}";
+        public string SegmentAriaLabelFormat { get; set; } = DefaultSegmentAriaLabelFormat;
 
         /// <summary>
         /// Called when the value of the security code changes.

--- a/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor.cs
+++ b/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor.cs
@@ -20,6 +20,25 @@ namespace MudX
         internal ParameterState<string?> _codeState;
         private bool _isInternalChange = false;
         private MudForm? _form = null!;
+        private string LabelId => $"{Id}-label";
+        private string HelperTextId => $"{Id}-helper-text";
+        private string ErrorTextId => $"{Id}-error-text";
+
+        private string? DescribedBy
+        {
+            get
+            {
+                var helperId = !string.IsNullOrWhiteSpace(HelperText) ? HelperTextId : null;
+                var errorId = Error && !string.IsNullOrWhiteSpace(ErrorText) ? ErrorTextId : null;
+                return (helperId, errorId) switch
+                {
+                    (not null, not null) => $"{helperId} {errorId}",
+                    (not null, null) => helperId,
+                    (null, not null) => errorId,
+                    _ => null
+                };
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MudXSecurityCode"/> class.
@@ -113,6 +132,57 @@ namespace MudX
         /// <remarks>Defaults to <c>null</c>.</remarks>
         [Parameter]
         public string? Code { get; set; }
+
+        /// <summary>
+        /// The visible label for the security code group.
+        /// </summary>
+        /// <remarks>Defaults to <c>null</c>.</remarks>
+        [Parameter]
+        public string? Label { get; set; }
+
+        /// <summary>
+        /// The helper text displayed beneath the security code group.
+        /// </summary>
+        /// <remarks>Defaults to <c>null</c>.</remarks>
+        [Parameter]
+        public string? HelperText { get; set; }
+
+        /// <summary>
+        /// Whether a value is required for every editable segment.
+        /// </summary>
+        /// <remarks>Defaults to <c>false</c>.</remarks>
+        [Parameter]
+        public bool Required { get; set; }
+
+        /// <summary>
+        /// Whether the editable security code segments are disabled.
+        /// </summary>
+        /// <remarks>Defaults to <c>false</c>.</remarks>
+        [Parameter]
+        public bool Disabled { get; set; }
+
+        /// <summary>
+        /// Whether the security code group is in an error state.
+        /// </summary>
+        /// <remarks>Defaults to <c>false</c>.</remarks>
+        [Parameter]
+        public bool Error { get; set; }
+
+        /// <summary>
+        /// The error text displayed when <see cref="Error" /> is <c>true</c>.
+        /// </summary>
+        /// <remarks>Defaults to <c>null</c>.</remarks>
+        [Parameter]
+        public string? ErrorText { get; set; }
+
+        /// <summary>
+        /// The accessible name for the security code group.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>. When set, this value takes precedence over <see cref="Label" /> for the group's accessible name.
+        /// </remarks>
+        [Parameter]
+        public string? AriaLabel { get; set; }
 
         /// <summary>
         /// Called when the value of the security code changes.
@@ -213,7 +283,10 @@ namespace MudX
         private IEnumerable<string> CharPatternValidator(int index, string val)
         {
             if (string.IsNullOrEmpty(val))
-                yield return "*";
+            {
+                if (Required && CodeItems[index].IsEditable)
+                    yield return "*";
+            }
             else if (val.Length > 1 && !IsValidInput(CodeItems[index].PatternChar, val))
                 yield return "*";
         }
@@ -336,7 +409,7 @@ namespace MudX
         /// <remarks>This method processes the pasted text by matching it against the editable and fixed
         /// characters in the code items. Editable code items are updated with valid characters from the pasted text,
         /// while fixed code items are set to their predefined values. After processing, the method updates the code
-        /// value, moves focus to the next focusable item, and validates the form if applicable.</remarks>
+        /// value, moves focus to the next focusable item, and runs the component's internal segmented-field validation.</remarks>
         /// <param name="fullid">The full identifier string, which must be at least 10 characters long. The substring after the first 10
         /// characters is used to determine the starting index for processing.</param>
         /// <param name="text">The text pasted from the clipboard. Cannot be null, empty, or consist only of whitespace.</param>

--- a/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor.cs
+++ b/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Globalization;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using MudBlazor;
@@ -27,11 +28,20 @@ namespace MudX
         private Dictionary<string, object?> GetInputAttributes(CodeItem item)
         {
             var attributes = new Dictionary<string, object?>(_attributes);
+            var hasExplicitAriaLabel = attributes.TryGetValue("aria-label", out var ariaLabel)
+                && !string.IsNullOrWhiteSpace(ariaLabel?.ToString());
             if (item.IsEditable)
             {
                 var ordinal = CodeItems.Take(item.Index + 1).Count(codeItem => codeItem.IsEditable);
                 var total = CodeItems.Count(codeItem => codeItem.IsEditable);
-                attributes["aria-label"] = $"Character {ordinal} of {total}";
+                if (!hasExplicitAriaLabel)
+                    attributes["aria-label"] = string.Format(CultureInfo.CurrentCulture, SegmentAriaLabelFormat, ordinal, total);
+            }
+            else
+            {
+                attributes["tabindex"] = "-1";
+                attributes["aria-hidden"] = "true";
+                attributes["inert"] = string.Empty;
             }
 
             return attributes;
@@ -196,6 +206,16 @@ namespace MudX
         /// </remarks>
         [Parameter]
         public string? AriaLabel { get; set; }
+
+        /// <summary>
+        /// The format used for each editable segment's accessible name.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>"Character {0} of {1}"</c>, where <c>{0}</c> is the segment position and <c>{1}</c> is the editable segment count.
+        /// An <c>aria-label</c> supplied through <see cref="MudComponentBase.UserAttributes" /> takes precedence.
+        /// </remarks>
+        [Parameter]
+        public string SegmentAriaLabelFormat { get; set; } = "Character {0} of {1}";
 
         /// <summary>
         /// Called when the value of the security code changes.

--- a/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor.cs
+++ b/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor.cs
@@ -24,20 +24,33 @@ namespace MudX
         private string HelperTextId => $"{Id}-helper-text";
         private string ErrorTextId => $"{Id}-error-text";
 
-        private string? DescribedBy
+        private Dictionary<string, object?> GetInputAttributes(CodeItem item)
         {
-            get
+            var attributes = new Dictionary<string, object?>(_attributes);
+            if (item.IsEditable)
             {
-                var helperId = !string.IsNullOrWhiteSpace(HelperText) ? HelperTextId : null;
-                var errorId = Error && !string.IsNullOrWhiteSpace(ErrorText) ? ErrorTextId : null;
-                return (helperId, errorId) switch
-                {
-                    (not null, not null) => $"{helperId} {errorId}",
-                    (not null, null) => helperId,
-                    (null, not null) => errorId,
-                    _ => null
-                };
+                var ordinal = CodeItems.Take(item.Index + 1).Count(codeItem => codeItem.IsEditable);
+                var total = CodeItems.Count(codeItem => codeItem.IsEditable);
+                attributes["aria-label"] = $"Character {ordinal} of {total}";
             }
+
+            return attributes;
+        }
+
+        private string? GetDescriptionIds(CodeItem item)
+        {
+            if (!item.IsEditable)
+                return null;
+
+            var helperId = !string.IsNullOrWhiteSpace(HelperText) ? HelperTextId : null;
+            var errorId = Error && !string.IsNullOrWhiteSpace(ErrorText) ? ErrorTextId : null;
+            return (helperId, errorId) switch
+            {
+                (not null, not null) => $"{helperId} {errorId}",
+                (not null, null) => helperId,
+                (null, not null) => errorId,
+                _ => null
+            };
         }
 
         /// <summary>

--- a/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor.cs
+++ b/src/MudX/Components/MudXSecurityCode/MudXSecurityCode.razor.cs
@@ -24,7 +24,15 @@ namespace MudX
         private string LabelId => $"{Id}-label";
         private string HelperTextId => $"{Id}-helper-text";
         private string ErrorTextId => $"{Id}-error-text";
+        private string? FirstEditableInputId => CodeItems.FirstOrDefault(item => item.IsEditable)?.InputId;
         private const string DefaultSegmentAriaLabelFormat = "Character {0} of {1}";
+
+        private Dictionary<string, object?> GetContainerAttributes()
+        {
+            return UserAttributes
+                .Where(attribute => !string.Equals(attribute.Key, "aria-label", StringComparison.OrdinalIgnoreCase))
+                .ToDictionary(attribute => attribute.Key, attribute => attribute.Value);
+        }
 
         private Dictionary<string, object?> GetInputAttributes(CodeItem item)
         {
@@ -228,11 +236,12 @@ namespace MudX
         /// </summary>
         /// <remarks>
         /// Defaults to <c>"Character {0} of {1}"</c>, where <c>{0}</c> is the segment position and <c>{1}</c> is the editable segment count.
-        /// An <c>aria-label</c> supplied through <see cref="MudComponentBase.UserAttributes" /> takes precedence.
+        /// An <c>aria-label</c> supplied through <see cref="MudComponentBase.UserAttributes" /> labels each editable segment and takes precedence.
+        /// It does not replace the group's accessible name.
         /// Null, blank, or malformed formats fall back to the default so every editable segment remains named.
         /// </remarks>
         [Parameter]
-        public string SegmentAriaLabelFormat { get; set; } = DefaultSegmentAriaLabelFormat;
+        public string? SegmentAriaLabelFormat { get; set; } = DefaultSegmentAriaLabelFormat;
 
         /// <summary>
         /// Called when the value of the security code changes.

--- a/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
+++ b/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
@@ -241,6 +241,54 @@ namespace MudX.UnitTests.Components
         }
 
         [Test]
+        public void SecurityCode_ShouldKeepFixedPatternCharactersOutOfSequentialFocus()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.Pattern, "#-#"));
+
+            // Assert
+            comp.FindAll("input:not([readonly])").Should().HaveCount(2)
+                .And.OnlyContain(input => !input.HasAttribute("tabindex"));
+            var fixedInput = comp.Find("input[readonly]");
+            fixedInput.GetAttribute("tabindex").Should().Be("-1");
+            fixedInput.GetAttribute("aria-hidden").Should().Be("true");
+            fixedInput.HasAttribute("inert").Should().BeTrue();
+        }
+
+        [Test]
+        public void SecurityCode_ShouldSupportLocalizedSegmentNames()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.SegmentAriaLabelFormat, "Caractère {0} sur {1}"));
+
+            // Assert
+            comp.FindAll("input:not([readonly])")
+                .Select(input => input.GetAttribute("aria-label"))
+                .Should().Equal(
+                    "Caractère 1 sur 4",
+                    "Caractère 2 sur 4",
+                    "Caractère 3 sur 4",
+                    "Caractère 4 sur 4");
+        }
+
+        [Test]
+        public void SecurityCode_ShouldPreserveExplicitSegmentAriaLabel()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.UserAttributes, new Dictionary<string, object?>
+                {
+                    ["aria-label"] = "Custom segment"
+                }));
+
+            // Assert
+            comp.FindAll("input:not([readonly])")
+                .Should().OnlyContain(input => input.GetAttribute("aria-label") == "Custom segment");
+        }
+
+        [Test]
         public async Task SecurityCode_ShouldAllowEmptyOptionalSegments()
         {
             // Arrange

--- a/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
+++ b/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
@@ -275,7 +275,9 @@ namespace MudX.UnitTests.Components
 
         [TestCase(null)]
         [TestCase("")]
+        [TestCase("   ")]
         [TestCase("Character {0")]
+        [TestCase("Character {2} of {1}")]
         public void SecurityCode_ShouldFallbackWhenSegmentAriaLabelFormatIsInvalid(string? format)
         {
             // Arrange
@@ -297,6 +299,7 @@ namespace MudX.UnitTests.Components
         {
             // Arrange
             var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.SegmentAriaLabelFormat, "Character {0")
                 .Add(p => p.UserAttributes, new Dictionary<string, object?>
                 {
                     ["aria-label"] = "Custom segment"

--- a/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
+++ b/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
@@ -273,6 +273,25 @@ namespace MudX.UnitTests.Components
                     "Caractère 4 sur 4");
         }
 
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("Character {0")]
+        public void SecurityCode_ShouldFallbackWhenSegmentAriaLabelFormatIsInvalid(string? format)
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.SegmentAriaLabelFormat, format!));
+
+            // Assert
+            comp.FindAll("input:not([readonly])")
+                .Select(input => input.GetAttribute("aria-label"))
+                .Should().Equal(
+                    "Character 1 of 4",
+                    "Character 2 of 4",
+                    "Character 3 of 4",
+                    "Character 4 of 4");
+        }
+
         [Test]
         public void SecurityCode_ShouldPreserveExplicitSegmentAriaLabel()
         {

--- a/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
+++ b/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
@@ -1,4 +1,5 @@
-﻿using AngleSharp.Dom;
+﻿using System.Reflection;
+using AngleSharp.Dom;
 using AwesomeAssertions;
 using Bunit;
 using MudBlazor;
@@ -184,6 +185,39 @@ namespace MudX.UnitTests.Components
         }
 
         [Test]
+        public void SecurityCode_ShouldKeepGroupAndSegmentAriaLabelOwnershipSeparate()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.AriaLabel, "Account verification code")
+                .Add(p => p.UserAttributes, new Dictionary<string, object?>
+                {
+                    ["aria-label"] = "Custom segment"
+                }));
+
+            // Assert
+            comp.Find(".mudx-code-container[role='group']")
+                .GetAttribute("aria-label").Should().Be("Account verification code");
+            comp.FindAll("input:not([readonly])")
+                .Should().OnlyContain(input => input.GetAttribute("aria-label") == "Custom segment");
+        }
+
+        [Test]
+        public void SecurityCode_ShouldAssociateVisibleLabelWithFirstEditableSegment()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.Pattern, "-##")
+                .Add(p => p.Label, "Verification code"));
+
+            // Assert
+            var label = comp.Find("label.mudx-code-label");
+            var firstEditableInput = comp.Find("input:not([readonly])");
+            label.GetAttribute("for").Should().Be(firstEditableInput.Id);
+            label.GetAttribute("for").Should().NotBe(comp.Find("input[readonly]").Id);
+        }
+
+        [Test]
         public void SecurityCode_ShouldOmitInactiveRequiredAndErrorSemantics()
         {
             // Act
@@ -273,6 +307,20 @@ namespace MudX.UnitTests.Components
                     "Caractère 4 sur 4");
         }
 
+        [Test]
+        public void SecurityCode_ShouldExposeNullableSegmentAriaLabelFormat()
+        {
+            // Arrange
+            var property = typeof(MudXSecurityCode).GetProperty(nameof(MudXSecurityCode.SegmentAriaLabelFormat));
+
+            // Act
+            var nullability = new NullabilityInfoContext().Create(property!);
+
+            // Assert
+            nullability.ReadState.Should().Be(NullabilityState.Nullable);
+            nullability.WriteState.Should().Be(NullabilityState.Nullable);
+        }
+
         [TestCase(null)]
         [TestCase("")]
         [TestCase("   ")]
@@ -282,7 +330,7 @@ namespace MudX.UnitTests.Components
         {
             // Arrange
             var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
-                .Add(p => p.SegmentAriaLabelFormat, format!));
+                .Add(p => p.SegmentAriaLabelFormat, format));
 
             // Assert
             comp.FindAll("input:not([readonly])")

--- a/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
+++ b/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
@@ -133,19 +133,36 @@ namespace MudX.UnitTests.Components
 
             // Assert
             var group = comp.Find(".mudx-code-container[role='group']");
+            comp.FindAll("[role='group']").Should().ContainSingle();
             var labelId = group.GetAttribute("aria-labelledby");
             labelId.Should().NotBeNullOrWhiteSpace();
             comp.FindAll($"#{labelId}").Should().ContainSingle()
                 .Which.TextContent.Should().Be("Verification code");
 
-            var descriptionIds = group.GetAttribute("aria-describedby")!
-                .Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            descriptionIds.Should().HaveCount(2);
-            descriptionIds.Select(id => comp.Find($"#{id}").TextContent)
-                .Should().BeEquivalentTo("Enter the code from your authenticator.", "The code is invalid.");
+            group.HasAttribute("aria-describedby").Should().BeFalse();
+            group.HasAttribute("aria-required").Should().BeFalse();
+            group.HasAttribute("aria-invalid").Should().BeFalse();
 
-            group.GetAttribute("aria-required").Should().Be("true");
-            group.GetAttribute("aria-invalid").Should().Be("true");
+            var inputs = comp.FindAll("input:not([readonly])");
+            inputs.Should().HaveCount(4);
+            inputs.Select(input => input.GetAttribute("aria-label")).Should().Equal(
+                "Character 1 of 4",
+                "Character 2 of 4",
+                "Character 3 of 4",
+                "Character 4 of 4");
+            inputs.Should().OnlyContain(input => input.GetAttribute("aria-required") == "true");
+            inputs.Should().OnlyContain(input => input.GetAttribute("aria-invalid") == "true");
+            foreach (var input in inputs)
+            {
+                var descriptionIds = input.GetAttribute("aria-describedby")!
+                    .Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                descriptionIds.Should().HaveCount(2);
+                descriptionIds.Select(id => comp.Find($"#{id}").TextContent)
+                    .Should().BeEquivalentTo("Enter the code from your authenticator.", "The code is invalid.");
+            }
+
+            comp.FindAll("[role='alert']").Should().ContainSingle()
+                .Which.TextContent.Should().Be("The code is invalid.");
             comp.Markup.Split("Verification code").Should().HaveCount(2);
             comp.Markup.Split("Enter the code from your authenticator.").Should().HaveCount(2);
             comp.Markup.Split("The code is invalid.").Should().HaveCount(2);
@@ -177,6 +194,34 @@ namespace MudX.UnitTests.Components
             group.HasAttribute("aria-required").Should().BeFalse();
             group.HasAttribute("aria-invalid").Should().BeFalse();
             group.HasAttribute("aria-describedby").Should().BeFalse();
+            comp.FindAll("[role='group']").Should().ContainSingle();
+            comp.FindAll("input:not([readonly])").Should().OnlyContain(input =>
+                input.GetAttribute("aria-required") == "false"
+                && input.GetAttribute("aria-invalid") == "false"
+                && !input.HasAttribute("aria-describedby"));
+        }
+
+        [Test]
+        public async Task SecurityCode_ShouldAnnounceErrorOnceWhenErrorStateChanges()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.HelperText, "Enter the code from your authenticator.")
+                .Add(p => p.ErrorText, "The code is invalid."));
+
+            // Act
+            await comp.InvokeAsync(() => comp.SetParametersAndRender(parameters => parameters
+                .Add(p => p.Error, true)));
+
+            // Assert
+            var inputs = comp.FindAll("input:not([readonly])");
+            inputs.Should().OnlyContain(input => input.GetAttribute("aria-invalid") == "true");
+            inputs.Should().OnlyContain(input => input.GetAttribute("aria-describedby")!
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .Select(id => comp.Find($"#{id}").TextContent)
+                .Contains("The code is invalid."));
+            comp.FindAll("[role='alert']").Should().ContainSingle()
+                .Which.TextContent.Should().Be("The code is invalid.");
         }
 
         [Test]

--- a/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
+++ b/tests/MudX.UnitTests/Components/SecurityCodeTests.cs
@@ -121,6 +121,110 @@ namespace MudX.UnitTests.Components
         }
 
         [Test]
+        public void SecurityCode_ShouldRenderAccessibleGroupSemantics()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.Label, "Verification code")
+                .Add(p => p.HelperText, "Enter the code from your authenticator.")
+                .Add(p => p.Required, true)
+                .Add(p => p.Error, true)
+                .Add(p => p.ErrorText, "The code is invalid."));
+
+            // Assert
+            var group = comp.Find(".mudx-code-container[role='group']");
+            var labelId = group.GetAttribute("aria-labelledby");
+            labelId.Should().NotBeNullOrWhiteSpace();
+            comp.FindAll($"#{labelId}").Should().ContainSingle()
+                .Which.TextContent.Should().Be("Verification code");
+
+            var descriptionIds = group.GetAttribute("aria-describedby")!
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            descriptionIds.Should().HaveCount(2);
+            descriptionIds.Select(id => comp.Find($"#{id}").TextContent)
+                .Should().BeEquivalentTo("Enter the code from your authenticator.", "The code is invalid.");
+
+            group.GetAttribute("aria-required").Should().Be("true");
+            group.GetAttribute("aria-invalid").Should().Be("true");
+            comp.Markup.Split("Verification code").Should().HaveCount(2);
+            comp.Markup.Split("Enter the code from your authenticator.").Should().HaveCount(2);
+            comp.Markup.Split("The code is invalid.").Should().HaveCount(2);
+        }
+
+        [Test]
+        public void SecurityCode_ShouldPreferExplicitAriaLabelForAccessibleName()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.Label, "Visible label")
+                .Add(p => p.AriaLabel, "Account verification code"));
+
+            // Assert
+            var group = comp.Find(".mudx-code-container[role='group']");
+            group.GetAttribute("aria-label").Should().Be("Account verification code");
+            group.HasAttribute("aria-labelledby").Should().BeFalse();
+            comp.Markup.Split("Visible label").Should().HaveCount(2);
+        }
+
+        [Test]
+        public void SecurityCode_ShouldOmitInactiveRequiredAndErrorSemantics()
+        {
+            // Act
+            var comp = Context.RenderComponent<MudXSecurityCode>();
+
+            // Assert
+            var group = comp.Find(".mudx-code-container[role='group']");
+            group.HasAttribute("aria-required").Should().BeFalse();
+            group.HasAttribute("aria-invalid").Should().BeFalse();
+            group.HasAttribute("aria-describedby").Should().BeFalse();
+        }
+
+        [Test]
+        public void SecurityCode_ShouldDisableEveryEditableSegment()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.Pattern, "#-#")
+                .Add(p => p.Disabled, true));
+
+            // Assert
+            var group = comp.Find(".mudx-code-container[role='group']");
+            group.GetAttribute("aria-disabled").Should().Be("true");
+            comp.FindAll("input:not([readonly])").Should().HaveCount(2)
+                .And.OnlyContain(input => input.HasAttribute("disabled"));
+            comp.Find("input[readonly]").HasAttribute("disabled").Should().BeFalse();
+        }
+
+        [Test]
+        public async Task SecurityCode_ShouldAllowEmptyOptionalSegments()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>();
+            var fields = comp.FindComponents<MudTextField<string>>();
+
+            // Act
+            await comp.InvokeAsync(() => Task.WhenAll(fields.Select(field => field.Instance.ValidateAsync())));
+
+            // Assert
+            fields.Should().OnlyContain(field => !field.Instance.HasErrors);
+        }
+
+        [Test]
+        public async Task SecurityCode_ShouldRejectEmptyRequiredSegments()
+        {
+            // Arrange
+            var comp = Context.RenderComponent<MudXSecurityCode>(parameters => parameters
+                .Add(p => p.Required, true));
+            var fields = comp.FindComponents<MudTextField<string>>();
+
+            // Act
+            await comp.InvokeAsync(() => Task.WhenAll(fields.Select(field => field.Instance.ValidateAsync())));
+
+            // Assert
+            fields.Should().OnlyContain(field => field.Instance.HasErrors);
+        }
+
+        [Test]
         public void SecurityCode_ShouldRenderWithCustomPattern()
         {
             // Arrange


### PR DESCRIPTION
## Summary

`MudXSecurityCode` previously rendered its segments without a coherent logical-field surface: consumers could not provide one accessible group name, helper text, required/disabled/error state, or a single error description. This adds an additive form-state API while preserving the existing segmented input, pattern, paste, and completion contracts.

The post-ready correction at exact head `01f2975a24bf0e01deab106c7e207b059cfa55b7` also separates group and segment label ownership, aligns the nullable segment-format contract, and restores native visible-label activation.

## Changes

- Add `Label`, `HelperText`, `Required`, `Disabled`, `Error`, `ErrorText`, `AriaLabel`, and localizable `SegmentAriaLabelFormat` parameters with generated API documentation.
- Render one named `role="group"`, give every editable segment a concise ordinal name, and associate helper/error descriptions and supported required/invalid state with the native inputs.
- Keep an explicit segment `aria-label` supplied through `UserAttributes` from replacing the group's `AriaLabel` or visible-label name.
- Associate the visible label with the first editable raw input so native click/tap activation focuses the field while fixed separators remain inert.
- Declare `SegmentAriaLabelFormat` nullable to match its documented null fallback while retaining the initialized default.
- Announce a changing error once while keeping helper and error content single-rendered.
- Remove fixed pattern characters from sequential focus and the accessibility tree while preserving the existing renderer, pattern indices, paste, and completion behavior.
- Fall back to the documented default segment names when a consumer supplies a null, blank, or malformed label format.
- Disable every editable segment without changing fixed pattern characters, and allow empty optional segments while retaining required validation.
- Add focused bUnit coverage plus a docs example for normal, error, and disabled form states.
- Clarify that `ClipboardPasteEvent` runs internal segmented-field validation rather than implying parent-form integration.

## Visual Evidence

The post-ready correction changes semantics and native label interaction without changing the visible layout, so the existing durable screenshots remain representative.

Before — desktop 1440x1000, base `551ea8ec` (no form-state section or logical group surface):

![before desktop](https://github.com/user-attachments/assets/afd9645f-d5d4-43ce-a273-721cf42a0177)

After — desktop 1440x1000, normal state:

![after desktop normal](https://github.com/user-attachments/assets/cfb75c1f-2732-402f-8eff-7d7735029798)

After — desktop 1440x1000, error and disabled states:

![after desktop error and disabled](https://github.com/user-attachments/assets/120c5a18-ac82-4d42-9a15-479fbf52298f)

## Tested With

- TDD regression run before production edits — 3 failed for the expected reasons: group name overridden by segment `aria-label`, visible label missing `for`, and nullable metadata reported `NotNull`.
- The same three focused regressions after correction — 3 passed, 0 failed.
- `dotnet test tests/MudX.UnitTests/MudX.UnitTests.csproj --filter "FullyQualifiedName~SecurityCode" --no-restore --nologo --blame-hang --blame-hang-timeout 30s` — 30 passed, 1 pre-existing ignored, 0 failed.
- `dotnet build src/MudX/MudX.csproj --framework net8.0|net9.0|net10.0 --no-restore --nologo` — all three targets succeeded with 0 errors; only existing obsolete `MudForm.Validate()` warnings appeared on net8/net9.
- `dotnet build src/MudX.Docs/MudX.Docs.csproj --no-restore --nologo` — succeeded; the matching API JSON was regenerated and a second pass reported no API changes.
- Scoped `dotnet format --verify-no-changes --no-restore` for the changed library, test, and docs paths — passed.
- `git diff --check` and JSON parse validation — passed.
- Playwright at 1440x1000 on `/docs/securitycode` — the group retained `Account verification code`; four editable inputs retained `Character 1 of 4` through `Character 4 of 4`; the visible label's `for` matched the first editable raw input ID; clicking it focused that input; fixed `/` separators remained inert, accessibility-hidden, and `tabindex=-1`; 0 page errors.
- Final range is six commits across the same seven intended files from base `551ea8ec29f336f6d7771fe34ba8f808f55124d8`.
- Fresh exact-head reviews passed at `01f2975a24bf0e01deab106c7e207b059cfa55b7`: Forge `codebringer-forge:00972` and Sentinel `sentinel:00973` accepted the correction with no remaining PR-introduced findings.

## Notes

- The public API is additive and does not change `Code`, pattern parsing, paste behavior, completion behavior, or claim OTP authentication.
- Mixed-pattern partial paste can focus past the next empty editable segment; this is unchanged base behavior and remains intentionally deferred from this form-state PR.
- Existing repository warnings remain unchanged from the base revision, including the AngleSharp advisory and obsolete internal `MudForm.Validate()` calls.

-- Coded by Codebringer / AI
-- Codebringer for versile2
-- versile2 approved