### PR TITLE
Update MudX to MudBlazor 9.9.0

### DIFF
--- a/src/MudX/MudX.csproj
+++ b/src/MudX/MudX.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Version>9.5.0</Version>
+        <Version>9.9.0</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -75,7 +75,7 @@
       <None Include="wwwroot\prism\prism.js" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="MudBlazor" Version="9.5.0" />
+      <PackageReference Include="MudBlazor" Version="9.9.0" />
     </ItemGroup>
    
     <!-- Create item with filename and timestamp metadata -->


### PR DESCRIPTION
## Summary

- update the MudX package version from 9.5.0 to 9.9.0
- update the MudBlazor dependency from 9.5.0 to stable 9.9.0

## Verification

- `dotnet restore src/MudX/MudX.csproj`
- `dotnet build src/MudX/MudX.csproj --no-restore --nologo`
- `dotnet test tests/MudX.UnitTests/MudX.UnitTests.csproj --nologo --blame-hang --blame-hang-timeout 30s` (146 passed, 2 skipped)

-- Coded by Codebringer / AI
-- Codebringer for versile2
-- versile2 requested changes